### PR TITLE
Allow ingress annotations and tls secret specification

### DIFF
--- a/controller/src/k8s_resources.py
+++ b/controller/src/k8s_resources.py
@@ -88,6 +88,9 @@ def create_template_values(metadata, spec):
         "full_url": urljoin(
             f"https://{spec['routing']['host']}", spec["routing"]["path"].rstrip("/")
         ),
+        # Session ingress
+        "ingress_tls_secret": spec["routing"]["tlsSecret"],
+        "ingress_annotations": spec["routing"]["ingressAnnotations"],
         # Volume
         "volume_size": spec["volume"]["size"],
         "volume_storage_class": spec["volume"]["storageClass"],

--- a/controller/src/templates/ingress.yaml
+++ b/controller/src/templates/ingress.yaml
@@ -2,18 +2,12 @@ kind: Ingress
 apiVersion: extensions/v1beta1
 metadata:
   name: {name}
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
-    kubernetes.io/ingress.class: nginx
-    kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 8k
-    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+  annotations: {ingress_annotations}
 spec:
   tls:
     - hosts:
         - {host}
-      secretName: {name}-js-tls
+      secretName: {ingress_tls_secret}
   rules:
     - host: {host}
       http:

--- a/helm-chart/templates/crd.yaml
+++ b/helm-chart/templates/crd.yaml
@@ -61,6 +61,10 @@ spec:
                     path:
                       type: string
                       default: "/"
+                    tlsSecret: 
+                      type: string
+                    ingressAnnotations: 
+                      type: string
 
                 volume:
                   type: object


### PR DESCRIPTION
This is a bit of a "quick and dirty" fix so that we do not hit the letsencrypt limits. I dont like how the annotations are specified but that seemed the easiest way I could think of without using a brand new library for making the k8s manifests from the templates in python.

I am ok to revert the annotations and keep them as they were (i.e. hardcoded in the template) if you think that is better.

This is currently deployed in my namespace. I tested it by launching a session and everything works.