### PR TITLE
chore: add workflow for chart publishing

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -1,0 +1,31 @@
+name: publish-chart
+
+on: [push]
+
+jobs:
+  publish-chart:
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Publish chart and push images
+        env:
+          DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+        run: |
+          cd helm-chart/
+          python -m pip install --upgrade pip pipenv
+          pipenv install --deploy --system --dev
+          git config --global user.email "renku@datascience.ch"
+          git config --global user.name "Renku Bot"
+          echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+          export TAG=$(echo ${GITHUB_REF} | cut -d/ -f3)
+          helm dep update amalthea
+          chartpress --tag $TAG
+          helm lint amalthea
+          chartpress --tag $TAG --push --publish-chart
+          chartpress --tag latest --push


### PR DESCRIPTION
Publish chart and images on tag, also tags the built image as `latests` and pushes it.

Tested on a test tag `0.0.0-tt1` (removed after testing), chart and images were correctly pushed, see https://github.com/SwissDataScienceCenter/amalthea/runs/2753360792?check_suite_focus=true

Partially resolves #15.