### PR TITLE
chore: set up ci test skeleton

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,40 @@
+name: tests
+
+on: [push]
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: engineerd/setup-kind@v0.5.0
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      # TODO: Adapt the chart building action in Renku to work for this repo too.
+      - name: Build chart, push images
+        env:
+          DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
+        run: |
+          echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+          cd helm-chart/
+          python -m pip install --upgrade pip pipenv
+          pipenv install --deploy --system --dev
+          helm dep update amalthea
+          chartpress --push
+
+      - name: Install amalthea chart
+        run: |
+          cd helm-chart/
+          helm install amalthea ./amalthea/ -n amalthea --create-namespace --set scope.namespaces={amalthea}
+          helm list -n amalthea
+
+      - name: Run tests
+        run: |
+          helm lint helm-chart/amalthea
+          # TODO: helm test amalthea
+          echo "helm test not yet set up"
+          # TODO: pytest
+          echo "no test suite available yet"


### PR DESCRIPTION
Set up a github workflow which installs the amalthea chart in a KinD cluster to run some tests. This closes #15 , actual tests will be added in #16.