### PR TITLE
feat(chart): template CRD name and API group/version

### DIFF
--- a/controller/src/config.py
+++ b/controller/src/config.py
@@ -2,9 +2,9 @@ import json
 import os
 import yaml
 
-api_group = "renku.io"
-api_version = "v1alpha1"
-custom_resource_name = "JupyterServer"
+api_group = os.getenv("CRD_API_GROUP", "andi.io")
+api_version = os.getenv("CRD_API_VERSION", "v1alpha1")
+custom_resource_name = os.getenv("CRD_NAME", "JupyterServer")
 
 # Strings which will be evaluated as true on env variables.
 TRUE_STRINGS = ["True", "true", "1"]

--- a/controller/src/server_controller.py
+++ b/controller/src/server_controller.py
@@ -20,10 +20,10 @@ JSONPATCH_OPS = {"MODIFIED": "replace", "ADDED": "add", "DELETED": "remove"}
 api_cache = ExpiringDict(max_len=100, max_age_seconds=60)
 
 
-PARENT_UID_LABEL_KEY = "amalthea.renku.io/parent-uid"
-PARENT_NAME_LABEL_KEY = "amalthea.renku.io/parent-name"
-CHILD_KEY_LABEL_KEY = "amalthea.renku.io/child-key"
-MAIN_POD_LABEL_KEY = "amalthea.renku.io/main-pod"
+PARENT_UID_LABEL_KEY = f"{config.api_group}/parent-uid"
+PARENT_NAME_LABEL_KEY = f"{config.api_group}/parent-name"
+CHILD_KEY_LABEL_KEY = f"{config.api_group}/child-key"
+MAIN_POD_LABEL_KEY = f"{config.api_group}/main-pod"
 
 
 def get_labels(

--- a/helm-chart/amalthea/templates/crd.yaml
+++ b/helm-chart/amalthea/templates/crd.yaml
@@ -2,18 +2,20 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: jupyterservers.renku.io
+  name: {{ .Values.crdNames.plural }}.{{ .Values.crdApiGroup }}
 spec:
   scope: Namespaced
-  group: renku.io
+  group: {{ .Values.crdApiGroup }}
   names:
-    kind: JupyterServer
-    plural: jupyterservers
-    singular: jupyterserver
+    kind: {{ .Values.crdNames.kind }}
+    plural: {{ .Values.crdNames.plural }}
+    singular: {{ .Values.crdNames.singular }}
     shortNames:
-      - js
+    {{- range .Values.crdNames.shortNames }}
+      - {{ . }}
+    {{- end }}
   versions:
-    - name: v1alpha1
+    - name: {{ .Values.crdApiVersion }}
       served: true
       storage: true
       additionalPrinterColumns:

--- a/helm-chart/amalthea/templates/deployment.yaml
+++ b/helm-chart/amalthea/templates/deployment.yaml
@@ -55,6 +55,12 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            - name: CRD_API_GROUP
+              value: {{ .Values.crdApiGroup }}
+            - name: CRD_API_VERSION
+              value: {{ .Values.crdApiVersion }}
+            - name: CRD_NAME
+              value: {{ .Values.crdNames.kind }}
             - name: RESCHEDULE_ON_NODE_FAILURE
               value: {{ .Values.rescheduleOnNodeFailure | quote }}
             - name: AMALTHEA_SELECTOR_LABELS

--- a/helm-chart/amalthea/templates/rbac/_rbac_rules.tpl
+++ b/helm-chart/amalthea/templates/rbac/_rbac_rules.tpl
@@ -5,8 +5,8 @@
     verbs: [create]
 
   # Amalthea: watching & handling for the custom resource we declare.
-  - apiGroups: [renku.io]
-    resources: [jupyterservers]
+  - apiGroups: [{{ .Values.crdApiGroup }}]
+    resources: [{{ .Values.crdNames.plural }}]
     verbs: [list, watch, patch]
 
   - apiGroups: [""]

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -95,3 +95,16 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Specify API group, version and custom resource names. You will very
+# likely never want to change any of this! This is mostly useful for
+# dev purposes as it allows multiple otherwise incompatible versions of
+# the CRD to co-exist in one cluster.
+crdApiGroup: renku.io
+crdApiVersion: v1alhpha1
+crdNames:
+  kind: JupyterServer
+  plural: jupyterservers
+  singular: jupyterserver
+  shortNames:
+    - js


### PR DESCRIPTION
Andiservers are currently served under the andi.io api in our dev cluster.