### PR TITLE
fix: replace notebook cookie secret value with file

### DIFF
--- a/controller/src/templates/statefulset.yaml
+++ b/controller/src/templates/statefulset.yaml
@@ -48,8 +48,8 @@ spec:
           command:
             - start-notebook.sh
           args:
-            - "--ServerApp.ip=0.0.0.0"
-            - "--NotebookApp.ip=0.0.0.0"
+            - "--ServerApp.ip=127.0.0.1"
+            - "--NotebookApp.ip=127.0.0.1"
             - "--ServerApp.port=8888"
             - "--NotebookApp.port=8888"
             - "--ServerApp.token=$(SERVER_APP_TOKEN)"


### PR DESCRIPTION
This was causing problems when launching older renku projects. It resolves two problems:
1. The cookie secret should be a bytes object rather than a plain string and this does not work well when passed as an argument variable
2. The value of localhost for the ip is not always recognized in older renku projects. After reverting to ~`0.0.0.0`~ `127.0.0.1` the issue does not occur with older projects.