### PR TITLE
fix: typo in api version name for crd

### DIFF
--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -101,7 +101,7 @@ affinity: {}
 # dev purposes as it allows multiple otherwise incompatible versions of
 # the CRD to co-exist in one cluster.
 crdApiGroup: renku.io
-crdApiVersion: v1alhpha1
+crdApiVersion: v1alpha1
 crdNames:
   kind: JupyterServer
   plural: jupyterservers


### PR DESCRIPTION
So this is why I had a bunch of additional weird problems yesterday I think.

Anyhow I got it now and now also the notebooks do not have this hardcoded so it wont really matter. But still.