### PR TITLE
Remove traefik

### DIFF
--- a/controller/k8s_resources.py
+++ b/controller/k8s_resources.py
@@ -65,7 +65,7 @@ def create_template_values(name, spec):
         "jupyter_server_cookie_secret": os.urandom(32).hex(),
         "name": name,
         "oidc": spec["auth"]["oidc"],
-        "path": spec["routing"]["path"].rstrip("/"),
+        "path": os.path.join("/", spec["routing"]["path"].rstrip("/")),
         "pvc": spec["storage"]["pvc"],
         "routing": spec["routing"],
         "storage": spec["storage"],

--- a/controller/templates/configmap.yaml
+++ b/controller/templates/configmap.yaml
@@ -5,8 +5,11 @@ metadata:
 data:
   jupyter_notebook_config.py: |
     import os
-    from urllib.parse import urlparse
+    {%- if oidc["enabled"] %}
     c.NotebookApp.ip="127.0.0.1"
+    {%- else %}
+    c.NotebookApp.ip="0.0.0.0"
+    {%- endif %}
     c.NotebookApp.port=8888
     c.NotebookApp.token=os.environ["SERVER_APP_TOKEN"]
     c.NotebookApp.cookie_secret_file="/etc/jupyter_server_secrets/cookie_secret"
@@ -15,12 +18,15 @@ data:
     c.NotebookApp.notebook_dir="{{ jupyter_server["rootDir"] }}"
     c.NotebookApp.default_url="{{ jupyter_server["defaultUrl"] }}"
     # Note that we could also just allow non-local hosts in general
-    c.NotebookApp.local_hostnames=["localhost", urlparse("{{ host_url }}").netloc]
+    c.NotebookApp.local_hostnames=["localhost", "{{ routing["host"] }}"]
 
   jupyter_server_config.py: |
     import os
-    from urllib.parse import urlparse
+    {%- if oidc["enabled"] %}
     c.ServerApp.ip="127.0.0.1"
+    {%- else %}
+    c.ServerApp.ip="0.0.0.0"
+    {%- endif %}
     c.ServerApp.port=8888
     c.ServerApp.token=os.environ["SERVER_APP_TOKEN"]
     c.ServerApp.cookie_secret_file="/etc/jupyter_server_secrets/cookie_secret"
@@ -29,98 +35,9 @@ data:
     c.ServerApp.root_dir="{{ jupyter_server["rootDir"] }}"
     c.ServerApp.default_url="{{ jupyter_server["defaultUrl"] }}"
     # Note that we could also just allow non-local hosts in general
-    c.ServerApp.local_hostnames=["localhost", urlparse("{{ host_url }}").netloc]
+    c.ServerApp.local_hostnames=["localhost", "{{ routing["host"] }}"]
 
-
-  proxy-rules.yaml: |
-    http:
-      routers:
-        proxy:
-          entryPoints:
-            - http
-          rule: PathPrefix(`/`)
-          middlewares:
-          {% if oidc["enabled"] %}
-            - oidcPlugin
-            - customAuthorization
-          {% endif %}
-          service: notebook
-
-      middlewares:
-        oidcPlugin:
-          forwardAuth:
-            address: 'http://localhost:4180/'
-            trustForwardHeader: true
-            authResponseHeaders:
-              - X-Auth-Request-Access-Token
-              - Authorization
-              - X-Auth-Request-User
-              - X-Auth-Request-Groups
-              - X-Auth-Request-Email
-              - X-Auth-Request-Preferred-Username
-        customAuthorization:
-          forwardAuth:
-            address: 'http://localhost:3000'
-
-      services:
-        notebook:
-          loadBalancer:
-            method: drr
-            servers:
-              - url: 'http://localhost:8888/'
-                weight: 1
-
-  # Note: We expose the oidc plugin through traefik in order
-  # to keep the ingress object simple. In principle traffic
-  # to /oauth2 could go from the ingress directly to the oidc
-  # plugin.
-
-  oidc-plugin-rules.yaml: |
-    http:
-      routers:
-        oidcPlugin:
-          entryPoints:
-            - http
-          rule: PathPrefix(`{{ path }}/oauth2/`)
-          middlewares:
-            - stripPath
-            - authHeaders
-          service: oidcPlugin
-
-      middlewares:
-        stripPath:
-          stripPrefix:
-            prefixes:
-              - {{ path }}
-
-        authHeaders:
-          headers:
-            browserXssFilter: true
-            contentTypeNosniff: true
-            forceSTSHeader: true
-            sslHost: {{ routing["host"] }}
-            stsIncludeSubdomains: true
-            stsPreload: true
-            frameDeny: true
-
-      services:
-        oidcPlugin:
-          loadBalancer:
-            method: drr
-            servers:
-              - url: 'http://localhost:4180/'
-                weight: 1
-
-  traefik.yaml: |
-    log:
-      level: debug
-    api:
-      dashboard: false
-    providers:
-      file:
-        directory: /config
-    entryPoints:
-      http:
-        address: ':8000'
-    accessLog:
-      bufferingSize: 10
+  authorized-users.txt: |
+    {%- for email in oidc["authorizedEmails"] %}
+    {{ email }}
+    {%- endfor %}

--- a/controller/templates/ingress.yaml
+++ b/controller/templates/ingress.yaml
@@ -14,7 +14,7 @@ spec:
     - host: {{ routing["host"] }}
       http:
         paths:
-        - path: {{ routing["path"] }}
+        - path: {{ path }}
           pathType: Prefix
           backend:
             service:

--- a/controller/templates/secret.yaml
+++ b/controller/templates/secret.yaml
@@ -11,6 +11,6 @@ data:
   {% if "value" in auth["oidc"]["clientSecret"] %}
   oidcClientSecret: {{ oidc["clientSecret"]["value"] | b64encode }}
   {% endif %}
-  authenticationPluginCookieSecret: {{ authentication_plugin_cookie_secret | b64encode }}
+  oauth2ProxyCookieSecret: {{ authentication_plugin_cookie_secret | b64encode }}
   {% endif %}
 

--- a/controller/templates/service.yaml
+++ b/controller/templates/service.yaml
@@ -9,7 +9,12 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 8000
+      {% if oidc["enabled"] %}
+      targetPort: 4180
+      {% else %}
+      targetPort: 8888
+      {% endif %}
+
   selector:
     app: {{ name }}
   ClusterIP: None

--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -17,10 +17,14 @@ spec:
       imagePullSecrets: []
       initContainers: []
       volumes:
-        - name: traefik-configmap
+        {% if oidc["enabled"] %}
+        - name: oauth2-proxy-config
           configMap:
             name: {{ name }}
-            defaultMode: 420
+            items:
+              - key: authorized-users.txt
+                path: authorized-users.txt
+        {% endif %}
         - name: jupyter-server-secrets
           secret:
             secretName: {{ name }}
@@ -93,74 +97,25 @@ spec:
             fsGroup: 100
             allowPrivilegeEscalation: false
 
-
-        - name: auth-proxy
-          image: "traefik:2.1.4"
-          args:
-            - "--configfile=/config/traefik.yaml"
-          ports:
-            - name: http
-              containerPort: 8000
-              protocol: TCP
-          resources:
-            requests:
-              cpu: 50m
-              memory: 32Mi
-            limits:
-              cpu: 200m
-              memory: 64Mi
-          volumeMounts:
-            - name: traefik-configmap
-              mountPath: /config
-          livenessProbe:
-            tcpSocket:
-              port: 8000
-            initialDelaySeconds: 10
-            timeoutSeconds: 2
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 3
-          readinessProbe:
-            tcpSocket:
-              port: 8000
-            initialDelaySeconds: 10
-            timeoutSeconds: 2
-            periodSeconds: 10
-            successThreshold: 1
-            failureThreshold: 1
-
         {% if oidc["enabled"] %}
-        - name: authorization-plugin
-          image: ableuler/auth-test:0.0.0-1
-          env:
-            - name: USER_ID
-              value: {{ oidc["userId"] }}
-          ports:
-            - name: http
-              containerPort: 3000
-              protocol: TCP
-          resources:
-            requests:
-              cpu: 20m
-              memory: 32Mi
-            limits:
-              cpu: 100m
-              memory: 64Mi
 
-        - name: authentication-plugin
-          image: "bitnami/oauth2-proxy:7.1.2"
+        - name: oauth2-proxy
+          image: "bitnami/oauth2-proxy:7.1.3"
           args:
             - "--provider=oidc"
             - "--client-id={{ oidc["clientId"] }}"
             - "--oidc-issuer-url={{ oidc["issuerUrl"] }}"
             - "--session-cookie-minimal"
-            - "--set-xauthrequest"
-            - "--email-domain=*"
             - "--http-address=:4180"
             - "--skip-provider-button"
-            - "--reverse-proxy"
-            - "--upstream=static://202"
+            - "--upstream=http://127.0.0.1:8888"
             - "--redirect-url={{ full_url }}/oauth2/callback"
+            - "--cookie-path={{ path }}"
+            - "--proxy-prefix={{ path }}/oauth2"
+            - "--authenticated-emails-file=/etc/oauth2-proxy/authorized-users.txt"
+            {% for group in oidc["authorizedGroups"] %}
+            - "--allowed-group={{ group }}"
+            {% endfor %}
           ports:
             - name: http
               containerPort: 4180
@@ -170,7 +125,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ name }}
-                  key: authenticationPluginCookieSecret
+                  key: oauth2ProxyCookieSecret
             - name: OAUTH2_PROXY_CLIENT_SECRET
               valueFrom:
               {% if "value" in auth["oidc"]["clientSecret"] %}
@@ -183,6 +138,10 @@ spec:
                   name: {{ auth["oidc"]["clientSecret"]["secretKeyRef"]["name"] }}
                   key: {{ auth["oidc"]["clientSecret"]["secretKeyRef"]["key"] }}
               {% endif %}
+          volumeMounts:
+            - name: oauth2-proxy-config
+              mountPath: /etc/oauth2-proxy/authorized-users.txt
+              subPath: authorized-users.txt
           resources:
             requests:
               cpu: 20m

--- a/examples/oidc.yaml
+++ b/examples/oidc.yaml
@@ -12,4 +12,8 @@ spec:
       issuerUrl: ## Issuer URL of OIDC provider
       clientId: ## Client ID of registered application
       clientSecret: ## Client secret of registered application
-      userId: ## ADD THE USER_ID OF THE USER WHO WILL HAVE ACCESS TO THE SERVER
+      authorizedEmails:
+        []
+        ## Email address of the user who is allowed access this server
+        # - me@example.com
+        # - myfriend@example.com

--- a/helm-chart/amalthea/templates/crd.yaml
+++ b/helm-chart/amalthea/templates/crd.yaml
@@ -173,8 +173,25 @@ spec:
                                 - value
                             - required:
                                 - secretKeyRef
-                        userId:
-                          type: string
+                        authorizedEmails:
+                          description: |
+                            List of users (identified by Email address read from the "email" OIDC claim)
+                            which are allowed to access this Jupyter session. This list is stored as a file
+                            and passed to the `--authenticated-emails-file` option (see
+                            https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#command-line-options).
+                          type: array
+                          default: []
+                          items:
+                            type: string
+                        authorizedGroups:
+                          description: |
+                            List of groups of users (read from the "groups" OIDC claim) which are allowed
+                            to access this Jupyter session. This list passed to the `--allowed-group` option (see
+                            https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#command-line-options).
+                          type: array
+                          default: []
+                          items:
+                            type: string
 
                 patches:
                   description: "Patches to be applied. Currently only json patches and json merge patches are supported."

--- a/tests/unit/test_manifest_auth.py
+++ b/tests/unit/test_manifest_auth.py
@@ -71,23 +71,15 @@ def test_auth_oidc(oidc_secret, valid_spec):
     secret = manifest["secret"]
     assert any(
         [
-            container["name"] == "authentication-plugin"
+            container["name"] == "oauth2-proxy"
             for container in manifest["statefulset"]["spec"]["template"]["spec"][
                 "containers"
             ]
         ]
     )
-    assert any(
-        [
-            container["name"] == "authorization-plugin"
-            for container in manifest["statefulset"]["spec"]["template"]["spec"][
-                "containers"
-            ]
-        ]
-    )
-    assert "authenticationPluginCookieSecret" in secret["data"].keys()
+    assert "oauth2ProxyCookieSecret" in secret["data"].keys()
     auth_container = manifest["statefulset"]["spec"]["template"]["spec"]["containers"][
-        3
+        1
     ]
     auth_container_oidc_secret = [
         env


### PR DESCRIPTION
This PR removes traefik and used the oauth2 proxy as a proxy and not just as forwardAuth middleware for traefik. As a side-effect of this, we also remove the custom authorization plugin which used to check if the `userId` added to the request by the oauth2 proxy matches the userId given as part of the JupyterServer spec. Instead, we rely on the built-in oauth2 proxy options, which are specifying a list of allowed Emails (read from the "email" claim) and/or a list of allowed groups (read from the "groups" claim). The CRD thus changes as part of this PR.