### PR TITLE
Fix broken jupyter container probes

### DIFF
--- a/controller/templates/configmap.yaml
+++ b/controller/templates/configmap.yaml
@@ -17,8 +17,7 @@ data:
     c.NotebookApp.base_url="{{ path }}"
     c.NotebookApp.notebook_dir="{{ jupyter_server["rootDir"] }}"
     c.NotebookApp.default_url="{{ jupyter_server["defaultUrl"] }}"
-    # Note that we could also just allow non-local hosts in general
-    c.NotebookApp.local_hostnames=["localhost", "{{ routing["host"] }}"]
+    c.NotebookApp.allow_remote_access=True
 
   jupyter_server_config.py: |
     import os
@@ -34,8 +33,7 @@ data:
     c.ServerApp.base_url="{{ path }}"
     c.ServerApp.root_dir="{{ jupyter_server["rootDir"] }}"
     c.ServerApp.default_url="{{ jupyter_server["defaultUrl"] }}"
-    # Note that we could also just allow non-local hosts in general
-    c.ServerApp.local_hostnames=["localhost", "{{ routing["host"] }}"]
+    c.ServerApp.allow_remote_access=True
 
   authorized-users.txt: |
     {%- for email in oidc["authorizedEmails"] %}

--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -89,9 +89,11 @@ spec:
               value: {{ storage["pvc"]["mountPath"] }}/.jupyter_config
           resources: {{ jupyter_server["resources"] | default({}) | tojson }}
           ports:
+          {% if not oidc["enabled"] %}
             - name: notebook-port
               containerPort: 8888
               protocol: TCP
+          {% endif %}
           securityContext:
             runAsUser: 1000
             runAsGroup: 100
@@ -103,30 +105,18 @@ spec:
           # Jupyter server can even accept connections. However, really long running tasks
           # should be put into an init container.
           livenessProbe:
-            httpGet:
-              httpHeaders:
-                - name: host
-                  value: 127.0.0.1:8888
-              path: {{ path }}
-              port: 8888
+            exec:
+              command:  ["sh", "-c", "jupyter notebook list | grep :8888/"]
             periodSeconds: 10
             failureThreshold: 6
           readinessProbe:
-            httpGet:
-              httpHeaders:
-                - name: host
-                  value: 127.0.0.1:8888
-              path: {{ path }}
-              port: 8888
+            exec:
+              command: ["sh", "-c", "jupyter notebook list | grep :8888/"]
             periodSeconds: 2
             failureThreshold: 2
           startupProbe:
-            httpGet:
-              httpHeaders:
-                - name: host
-                  value: 127.0.0.1:8888
-              path: {{ path }}
-              port: 8888
+            exec:
+              command: ["sh", "-c", "jupyter notebook list | grep :8888/"]
             periodSeconds: 1
             failureThreshold: 300
 


### PR DESCRIPTION
This time the probes actually work... I've decided to go for the `jupyter notebook list` command and use it to check for a running server at port 8888. Note that this seems to work independent on wether the server was launched through `jupyter notebook` or `jupyter lab`.