### PR TITLE
chore(tests): do not push docker images to renku repo when doing tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - uses: helm/kind-action@v1.2.0
+        with:
+          cluster_name: kind
+          wait: 10m0s
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,17 +20,17 @@ jobs:
           python-version: 3.8
 
       # TODO: Adapt the chart building action in Renku to work for this repo too.
-      - name: Build chart, push images
+      - name: Build images, load in kind
         env:
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
         run: |
-          echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
           python -m pip install --upgrade pip pipenv
           pipenv install --deploy --system --dev
           cd helm-chart/
           helm dep update amalthea
-          PIPENV_PIPFILE="../Pipfile" pipenv run chartpress --push
+          pipenv run chartpress
+          kind load docker-image $(pipenv run chartpress --list-images) 
 
       - name: Install amalthea chart
         run: |


### PR DESCRIPTION
Should fix the failing workflows from PRs that are not part of the SDSC org. There is no need to login to the renku docker repo to push images for testing.