### PR TITLE
fix(app): faililng k8s probes for rstudio

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -104,4 +104,4 @@ jobs:
           ENVIRONMENT: ${{ matrix.test-image.env }}
         with:
           working-directory: acceptance-tests
-          command: npx mocha test.js
+          command: npx browserslist@latest --update-db && npx mocha test.js

--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -114,7 +114,7 @@ spec:
               # Required because rstudio sends a 404 even if everything is ok and the user-agent is left out.
               httpHeaders:
                 - name: User-Agent
-                  value: "Mozilla/5.0"
+                  value: "Mozilla/5.0 Firefox"
               path: {{ path }}
               port: 8888
             periodSeconds: 10
@@ -125,7 +125,7 @@ spec:
               httpHeaders:
               # Required because rstudio sends a 404 even if everything is ok and the user-agent is left out.
                 - name: User-Agent
-                  value: "Mozilla/5.0"
+                  value: "Mozilla/5.0 Firefox"
               path: {{ path }}
               port: 8888
             periodSeconds: 10
@@ -136,7 +136,7 @@ spec:
               httpHeaders:
               # Required because rstudio sends a 404 even if everything is ok and the user-agent is left out.
                 - name: User-Agent
-                  value: "Mozilla/5.0"
+                  value: "Mozilla/5.0 Firefox"
               path: {{ path }}
               port: 8888
             periodSeconds: 10

--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -114,7 +114,7 @@ spec:
               # Required because rstudio sends a 404 even if everything is ok and the user-agent is left out.
               httpHeaders:
                 - name: User-Agent
-                  value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
+                  value: "Mozilla/5.0"
               path: {{ path }}
               port: 8888
             periodSeconds: 10
@@ -125,7 +125,7 @@ spec:
               httpHeaders:
               # Required because rstudio sends a 404 even if everything is ok and the user-agent is left out.
                 - name: User-Agent
-                  value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
+                  value: "Mozilla/5.0"
               path: {{ path }}
               port: 8888
             periodSeconds: 10
@@ -136,7 +136,7 @@ spec:
               httpHeaders:
               # Required because rstudio sends a 404 even if everything is ok and the user-agent is left out.
                 - name: User-Agent
-                  value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
+                  value: "Mozilla/5.0"
               path: {{ path }}
               port: 8888
             periodSeconds: 10

--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -111,6 +111,10 @@ spec:
           # should be put into an init container.
           livenessProbe:
             httpGet:
+              # Required because rstudio sends a 404 even if everything is ok and the user-agent is left out.
+              httpHeaders:
+                - name: User-Agent
+                  value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
               path: {{ path }}
               port: 8888
             periodSeconds: 10
@@ -118,6 +122,10 @@ spec:
             timeoutSeconds: 9
           readinessProbe:
             httpGet:
+              httpHeaders:
+              # Required because rstudio sends a 404 even if everything is ok and the user-agent is left out.
+                - name: User-Agent
+                  value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
               path: {{ path }}
               port: 8888
             periodSeconds: 10
@@ -125,6 +133,10 @@ spec:
             timeoutSeconds: 9
           startupProbe:
             httpGet:
+              httpHeaders:
+              # Required because rstudio sends a 404 even if everything is ok and the user-agent is left out.
+                - name: User-Agent
+                  value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
               path: {{ path }}
               port: 8888
             periodSeconds: 10


### PR DESCRIPTION
So it seems that rstudio returns 404 even if everything is ok but the request to it does not contain a `User-Agent` header so that it looks like the request is coming from a browser.

This made our k8s probes fail for no real reason.

Adding this to the header of the probes solves the problem.

Currently deployed at tasko.dev.renku.ch. I also tested that it does not mess up the probes for regular jupyterlab images.

If you want to test with a rstudio project, there is a public one here: https://tasko.dev.renku.ch/projects/tasko.olevski/test-r-1

This is the discourse post that helped: 
https://community.rstudio.com/t/opening-rstudio-using-aws-ssl-certificate/22006/20