### PR TITLE
fix(chart): allow egress to any port out of cluster

### DIFF
--- a/helm-chart/amalthea/templates/networkpolicies.yaml
+++ b/helm-chart/amalthea/templates/networkpolicies.yaml
@@ -47,7 +47,8 @@ spec:
       - port: 53
         protocol: TCP
     - to:
-      # Allow access to web outside of cluster by excluding
+      # Allow access to any port/protocol as long as it is directed
+      # outside of the cluster. This is done by excluding
       # IP ranges which are reserved for private networking from
       # the allowed range.
       - ipBlock:
@@ -56,11 +57,6 @@ spec:
           - 10.0.0.0/8
           - 172.16.0.0/12
           - 192.168.0.0/16
-      ports:
-      - port: 80
-        protocol: TCP
-      - port: 443
-        protocol: TCP
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
So removing the port section out of the egress network policy makes all ports available. And we do not have to specify ranges. With this change all egress, as long as it is directed to stuff outside of the cluster, regardless of which port/protocol it is, is allowed.

closes https://github.com/SwissDataScienceCenter/renku-notebooks/issues/798

Tested this on tasko.dev.renku.ch:

Hitting an external service on port 2222 works
```
curl empty-tasko.iac.dev.renku.ch:2222 -v
*   Trying 86.119.40.248:2222...
* TCP_NODELAY set
* Connected to empty-tasko.iac.dev.renku.ch (86.119.40.248) port 2222 (#0)
> GET / HTTP/1.1
> Host: empty-tasko.iac.dev.renku.ch:2222
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Received HTTP/0.9 when not allowed

* Closing connection 0
curl: (1) Received HTTP/0.9 when not allowed
```

Trying to hit a postgres instance inside the cluster fails:
```
curl tasko-renku-postgresql:5432 -v
*   Trying 10.43.58.118:5432...
* TCP_NODELAY set
* connect to 10.43.58.118 port 5432 failed: Connection timed out
* Failed to connect to tasko-renku-postgresql port 5432: Connection timed out
* Closing connection 0
curl: (28) Failed to connect to tasko-renku-postgresql port 5432: Connection timed out
```