### PR TITLE
fix(app): ignore the number of kernels when culling sessions

### DIFF
--- a/controller/server_controller.py
+++ b/controller/server_controller.py
@@ -137,7 +137,6 @@ def cull_idle_jupyter_servers(body, name, namespace, logger, **kwargs):
         cpu_usage <= config.CPU_USAGE_MILLICORES_IDLE_THRESHOLD
         and type(js_server_status) is dict
         and js_server_status.get("connections", 0) == 0
-        and js_server_status.get("kernels", 0) == 0
         and (
             now - js_server_status.get("last_activity", now).astimezone(pytz.UTC)
         ).total_seconds()


### PR DESCRIPTION
The culling currently checks that a session has zero kernels to consider this session idle. I think this is overly generous.

We have some very old sessions that have no activity but 10 kernels.

```
Checking idle status of session anon-XXXXXX, idle seconds: 0, cpu usage: 11.878941m, server status: {'connections': 0, 'kernels': 10, 'last_activity': datetime.datetime(2021, 11, 15, 20, 9, 49, 812356, tzinfo=datetime.timezone.utc), 'started': datetime.datetime(2021, 11, 15, 17, 30, 55, 843291, tzinfo=datetime.timezone.utc)}
```

Therefore, we should not take into account the number of kernels at all when deciding whether a session is idle.