### PR TITLE
fix(test): cleanup of k8s resources in fixtures

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -73,7 +73,10 @@ def operator(k8s_namespace, operator_env, k8s_amalthea_api, kopf_log_files_fp):
         stdout = stdout_content.decode()
     if type(stderr_content) is bytes:
         stderr_content = stderr_content.decode()
-    term_width = os.get_terminal_size().columns
+    try:
+        term_width = os.get_terminal_size().columns
+    except OSError:
+        term_width = 80
     print(" KOPF STDOUT ".center(term_width, "*"))
     print(stdout_content)
     print(" KOPF STDERR ".center(term_width, "*"))


### PR DESCRIPTION
The operator runs in a subprocess during the integration tests.

The problem is that once the operator is shut down then any outstanding jupyterservers cannot be cleaned up. And I did not realize that the subprocess where the operator was running was actively (and immediately) picking up the Ctrl-C of a cancelled test. This makes total sense in retrospect.

Now that the Ctrl-C signal is ignored, the operator can run long enough so that things are cleaned up. Even when tests are cancelled.

I also tested that the cleanup happens properly when a test fails or when an error occurs in one of the tests.