### PR TITLE
fix: allow number or string for disk size in CRD

### DIFF
--- a/helm-chart/amalthea/crd-spec.yaml
+++ b/helm-chart/amalthea/crd-spec.yaml
@@ -228,6 +228,6 @@ spec:
           description:
             Size of the PVC or sizeLimit of the emptyDir volume which backs the
             session respectively.
-          type: string
+          x-kubernetes-int-or-string: true
       type: object
   type: object


### PR DESCRIPTION
K8s allows numbers (interpreted as bytes) for memory/disk size.

However in the CRD we ask the user to specify disk size and then pass that on to PVC or emptyDir specs. But the CRD limits this only to strings.

With this we accept both strings and numbers.

I did some tests locally to ensure that PVCs and emptyDirs will accept the values - and they do.