### PR TITLE
fix(app): use group in dynamic k8s client

### DIFF
--- a/controller/server_controller.py
+++ b/controller/server_controller.py
@@ -123,7 +123,7 @@ def cull_idle_jupyter_servers(body, name, namespace, logger, **kwargs):
     except KeyError:
         return
     cpu_usage = get_cpu_usage_for_culling(pod=pod_name, namespace=namespace)
-    custom_resource_api = get_api(config.api_version, config.custom_resource_name)
+    custom_resource_api = get_api(config.api_version, config.custom_resource_name, config.api_group)
     idle_seconds = int(body["status"].get("idleSeconds", 0))
     now = pytz.UTC.localize(datetime.utcnow())
     last_activity = js_server_status.get("last_activity", now)
@@ -279,7 +279,7 @@ def update_status(body, event, labels, logger, meta, name, namespace, uid, **_):
 
     # We use the dynamic client for patching since we need
     # content_type="application/json-patch+json"
-    custom_resource_api = get_api(config.api_version, config.custom_resource_name)
+    custom_resource_api = get_api(config.api_version, config.custom_resource_name, config.api_group)
     try:
         custom_resource_api.patch(
             namespace=namespace,
@@ -334,7 +334,7 @@ def update_resource_usage(body, name, namespace, **kwargs):
             }
         }
     }
-    custom_resource_api = get_api(config.api_version, config.custom_resource_name)
+    custom_resource_api = get_api(config.api_version, config.custom_resource_name, config.api_group)
     try:
         custom_resource_api.patch(
             namespace=namespace,

--- a/controller/utils.py
+++ b/controller/utils.py
@@ -189,20 +189,20 @@ def parse_du_command(capacity, bytes_multiplier=1024):
     return None
 
 
-def get_api(api_version, kind):
+def get_api(api_version, kind, group=None):
     """
     Get the proper API for a certain resource. We cache the resources
     availabe in the cluster for 60 seconds in order to reduce the amount
     of unnecessary requests in busy clusters.
     """
     try:
-        return api_cache[(api_version, kind)]
+        return api_cache[(api_version, kind, group)]
     except KeyError:
         client = dynamic.DynamicClient(api_client.ApiClient())
         api_cache[(api_version, kind)] = client.resources.get(
-            api_version=api_version, kind=kind
+            api_version=api_version, kind=kind, group=group,
         )
-        return api_cache[(api_version, kind)]
+        return api_cache[(api_version, kind, group)]
 
 
 def convert_to_bytes(value):

--- a/controller/utils.py
+++ b/controller/utils.py
@@ -199,7 +199,7 @@ def get_api(api_version, kind, group=None):
         return api_cache[(api_version, kind, group)]
     except KeyError:
         client = dynamic.DynamicClient(api_client.ApiClient())
-        api_cache[(api_version, kind)] = client.resources.get(
+        api_cache[(api_version, kind, group)] = client.resources.get(
             api_version=api_version, kind=kind, group=group,
         )
         return api_cache[(api_version, kind, group)]


### PR DESCRIPTION
Some recent issues were possibly related to this.

It was never confirmed whether this would have helped or not. But it is still a good idea to use the API group if available to avoid confusion and problems in the future.

I checked the python k8s client and when the group is not passed in to the `resource.get` function it defaults to `None`