### PR TITLE
chore: run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM python:3.8-slim
 LABEL maintainer="info@datascience.ch"
 
 RUN pip install --no-cache-dir --disable-pip-version-check -U pip && \
-    pip install --no-cache-dir --disable-pip-version-check pipenv
+    pip install --no-cache-dir --disable-pip-version-check pipenv && \
+    groupadd -g 1000 amalthea && \
+    useradd -u 1000 -g 1000 amalthea
 
 # Install all packages
 WORKDIR /app
@@ -13,4 +15,5 @@ RUN pipenv install --system --deploy
 COPY controller /app/controller
 COPY kopf_entrypoint.py ./
 
+USER 1000:1000
 ENTRYPOINT ["kopf", "run", "--liveness=http://0.0.0.0:8080/healthz", "./kopf_entrypoint.py"]

--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -149,6 +149,8 @@ spec:
         {% if oidc["enabled"] %}
         - name: oauth2-proxy
           image: "bitnami/oauth2-proxy:7.1.3"
+          securityContext:
+            allowPrivilegeEscalation: false
           args:
             - "--provider=oidc"
             - "--client-id={{ oidc["clientId"] }}"
@@ -201,6 +203,10 @@ spec:
         {% else %}
         - name: passthrough-proxy
           image: traefik:v2.5
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
           args:
            - --entryPoints.web.address=:4180
            - --providers.file.directory=/traefik

--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -102,8 +102,8 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 100
-            fsGroup: 100
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
 
           # We allow quite some time (5 + 1 minutes) for the jupyter container to come up in
           # case the entrypoint contains a lot of code which has to be executed before the
@@ -151,6 +151,7 @@ spec:
           image: "bitnami/oauth2-proxy:7.1.3"
           securityContext:
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - "--provider=oidc"
             - "--client-id={{ oidc["clientId"] }}"
@@ -207,6 +208,7 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
            - --entryPoints.web.address=:4180
            - --providers.file.directory=/traefik

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -85,11 +85,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext:
-  runAsGroup: 1000
-  runAsUser: 1000
+podSecurityContext: {}
 
 securityContext:
+  runAsGroup: 1000
+  runAsUser: 1000
+  runAsNonRoot: true
   allowPrivilegeEscalation: false
 
 resources:

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -85,9 +85,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  runAsGroup: 1000
+  runAsUser: 1000
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
 
 resources:
   limits:


### PR DESCRIPTION
Run the amalthea operator as non-root.

Adds non-root users to session containers as well as setting `allowPrivilegeEscalations` to false.

closes #153 