### PR TITLE
chore: add renku-python as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 
-*           @ableuler @olevski @SwissDataScienceCenter/YAT
+*           @ableuler @olevski @SwissDataScienceCenter/YAT @SwissDataScienceCenter/renku-python-maintainers


### PR DESCRIPTION
The current branch protection rules require approval from a code owner so that PRs can be merged.

Renku-python should be in this list.