### PR TITLE
feat(app): add and modify prometheus metrics

### DIFF
--- a/controller/config.py
+++ b/controller/config.py
@@ -74,7 +74,7 @@ MAIN_POD_LABEL_KEY = f"{api_group}/main-pod"
 
 METRICS_ENABLED = os.environ.get("METRICS_ENABLED", "false").lower() == "true"
 METRICS_EXTRA_LABELS = json.loads(os.environ.get("METRICS_EXTRA_LABELS", "[]"))
-METRICS_EXTRA_LABELS_SANITIZED = [
+METRICS_EXTRA_LABELS_SANITIZED = tuple([
     sanitize_prometheus_metric_label_name(i) for i in METRICS_EXTRA_LABELS
-]
+])
 METRICS_PORT = int(os.environ.get("METRICS_PORT", 8765))

--- a/controller/culling.py
+++ b/controller/culling.py
@@ -1,9 +1,10 @@
+from dateutil import parser
 from json.decoder import JSONDecodeError
 import logging
 import requests
 from requests.exceptions import RequestException
 
-from controller.utils import get_pod_metrics, parse_pod_metrics, k8s_timestamp_to_utc_datetime
+from controller.utils import get_pod_metrics, parse_pod_metrics
 
 
 def get_cpu_usage_for_culling(pod, namespace):
@@ -73,7 +74,7 @@ def get_js_server_status(js_body):
         return None
 
     if type(res) is dict and "last_activity" in res.keys():
-        res["last_activity"] = k8s_timestamp_to_utc_datetime(res["last_activity"])
+        res["last_activity"] = parser.isoparse(res["last_activity"])
     if type(res) is dict and "started" in res.keys():
-        res["started"] = k8s_timestamp_to_utc_datetime(res["started"])
+        res["started"] = parser.isoparse(res["started"])
     return res

--- a/controller/culling.py
+++ b/controller/culling.py
@@ -1,11 +1,9 @@
-from datetime import datetime
 from json.decoder import JSONDecodeError
 import logging
-import pytz
 import requests
 from requests.exceptions import RequestException
 
-from controller.utils import get_pod_metrics, parse_pod_metrics
+from controller.utils import get_pod_metrics, parse_pod_metrics, k8s_timestamp_to_utc_datetime
 
 
 def get_cpu_usage_for_culling(pod, namespace):
@@ -75,19 +73,7 @@ def get_js_server_status(js_body):
         return None
 
     if type(res) is dict and "last_activity" in res.keys():
-        res["last_activity"] = datetime.fromisoformat(
-            res["last_activity"][:-1] + "+00:00"
-            if res["last_activity"].endswith("Z")
-            else res["last_activity"]
-        ).astimezone(
-            pytz.utc
-        )  # ensure timestamp is UTC
+        res["last_activity"] = k8s_timestamp_to_utc_datetime(res["last_activity"])
     if type(res) is dict and "started" in res.keys():
-        res["started"] = datetime.fromisoformat(
-            res["started"][:-1] + "+00:00"
-            if res["started"].endswith("Z")
-            else res["started"]
-        ).astimezone(
-            pytz.utc
-        )  # ensure timestamp is UTC
+        res["started"] = k8s_timestamp_to_utc_datetime(res["started"])
     return res

--- a/controller/metrics.py
+++ b/controller/metrics.py
@@ -1,43 +1,63 @@
 from dataclasses import dataclass
-from prometheus_client import Counter, Gauge
-from typing import Dict
+from prometheus_client import Counter, Histogram
+from typing import Dict, Union
 
 from controller import config
 
 
 @dataclass
 class Metrics:
-    total_launch: Counter = Counter(
-        "sessions_launch_total",
-        "Number of sessions launched",
+    sessions_total_created: Counter = Counter(
+        "sessions_total_created",
+        "Number of sessions created",
         labelnames=config.METRICS_EXTRA_LABELS_SANITIZED
     )
-    total_failed: Counter = Counter(
-        "sessions_failed_total",
-        "Number of sessions which have failed being launched",
+    sessions_total_deleted: Counter = Counter(
+        "sessions_total_deleted",
+        "Number of sessions deleted",
         labelnames=config.METRICS_EXTRA_LABELS_SANITIZED
     )
-    num_of_sessions: Gauge = Gauge(
-        "sessions_all",
-        "Number of sessions",
+    sessions_status_changes: Counter = Counter(
+        "sessions_status_changes",
+        "Number of times a status change has occured",
+        labelnames=[
+            *config.METRICS_EXTRA_LABELS_SANITIZED,
+            "status_from",
+            "status_to",
+        ]
+    )
+    sessions_launch_duration: Histogram = Histogram(
+        "sessions_launch_duration_seconds",
+        "How long did it take for a session to transition into running state",
+        unit="seconds",
         labelnames=config.METRICS_EXTRA_LABELS_SANITIZED
     )
-    num_of_running_sessions: Gauge = Gauge(
-        "sessions_running",
-        "Number of sessions in running state",
-        labelnames=config.METRICS_EXTRA_LABELS_SANITIZED,
+    sessions_cpu_request: Histogram = Histogram(
+        "sessions_cpu_request_millicores",
+        "CPU millicores requested by a user for a session.",
+        unit="m",
+        labelnames=config.METRICS_EXTRA_LABELS_SANITIZED
     )
-    num_of_starting_sessions: Gauge = Gauge(
-        "sessions_starting",
-        "Number of sessions which have been scheduled but are still starting",
-        labelnames=config.METRICS_EXTRA_LABELS_SANITIZED,
+    sessions_memory_request: Histogram = Histogram(
+        "sessions_memory_request_bytes",
+        "Memory requested by a user for a session.",
+        unit="byte",
+        labelnames=config.METRICS_EXTRA_LABELS_SANITIZED
+    )
+    sessions_disk_request: Histogram = Histogram(
+        "sessions_disk_request_bytes",
+        "Disk space requested by a user for a session.",
+        unit="byte",
+        labelnames=config.METRICS_EXTRA_LABELS_SANITIZED
     )
 
     def manipulate(
         self,
         metric_name: str,
         operation: str,
+        value: Union[int, float],
         manifest_labels: Dict[str, str] = {},
+        extra_labels: Dict[str, str] = {},
     ):
         metric = getattr(self, metric_name)
         if len(config.METRICS_EXTRA_LABELS) > 0:
@@ -52,5 +72,5 @@ class Metrics:
                     # lable that is exepected to exist in the manifest does not then
                     # the metric label will not be applied, but the metric will be counted
                     labels[config.METRICS_EXTRA_LABELS_SANITIZED[i]] = "Unknown"
-            metric = metric.labels(**labels)
-        getattr(metric, operation)()
+            metric = metric.labels(**labels, **extra_labels)
+        getattr(metric, operation)(value)

--- a/controller/server_controller.py
+++ b/controller/server_controller.py
@@ -302,6 +302,7 @@ def update_server_state(body, labels, namespace, **_):
         old_status = server.get("status", {}).get("state")
     # NOTE: Updating the status for deletions is handled in a specific delete handler
     if old_status != new_status.value and new_status.value != ServerStatusEnum.Stopping.value:
+        now = pytz.UTC.localize(datetime.utcnow())
         try:
             api.patch(
                 namespace=namespace,
@@ -309,6 +310,12 @@ def update_server_state(body, labels, namespace, **_):
                 body={
                     "status": {
                         "state": new_status.value,
+                        "startingSince": (
+                            now.isoformat() if new_status is ServerStatusEnum.Starting else None
+                        ),
+                        "failedSince": (
+                            now.isoformat() if new_status is ServerStatusEnum.Failed else None
+                        ),
                     },
                 },
                 content_type=CONTENT_TYPES["merge-patch"],

--- a/controller/server_controller.py
+++ b/controller/server_controller.py
@@ -184,7 +184,7 @@ def state_changed(old, new, labels, body, **_):
             labels,
         )
 
-    if new == ServerStatusEnum.Starting.value:
+    elif new == ServerStatusEnum.Starting.value:
         cpu_request = body.get("spec", {}).get("jupyterServer", {}).get("resources", {})\
             .get("requests", {}).get("cpu")
         memory_request = body.get("spec", {}).get("jupyterServer", {}).get("resources", {})\

--- a/controller/server_controller.py
+++ b/controller/server_controller.py
@@ -14,6 +14,9 @@ from controller.utils import (
     get_volume_disk_capacity,
     get_api,
     parse_pod_metrics,
+    k8s_timestamp_to_utc_datetime,
+    convert_to_bytes,
+    convert_to_millicores,
 )
 from controller.metrics import Metrics
 
@@ -91,9 +94,6 @@ def create_fn(labels, logger, name, namespace, spec, uid, **_):
     Watch the creation of jupyter server objects and create all
     the necessary k8s child resources which make the actual jupyter server.
     """
-    metrics.manipulate("total_launch", "inc", labels)
-    metrics.manipulate("num_of_sessions", "inc", labels)
-    metrics.manipulate("num_of_starting_sessions", "inc", labels)
 
     children_specs = get_children_specs(name, spec, logger)
 
@@ -120,6 +120,8 @@ def create_fn(labels, logger, name, namespace, spec, uid, **_):
             namespace=namespace, body=child_spec
         ).metadata.uid
 
+    metrics.manipulate("sessions_total_created", "inc", 1, labels)
+
     return {"createdResources": children_uids, "fullServerURL": get_urls(spec)[1]}
 
 
@@ -128,23 +130,35 @@ def delete_fn(labels, body, namespace, name, **_):
     """
     The juptyer server has been deleted.
     """
-    current_state = body.get("status", {}).get("state", ServerStatusEnum.Starting.value)
     api = get_api(config.api_version, config.custom_resource_name, config.api_group)
+    new_status = ServerStatusEnum.Stopping.value
+    if body:
+        old_status = body.get("status", {}).get("state")
+    else:
+        old_status = None
+    if old_status != new_status:
+        extra_labels = {
+            "status_from": str(old_status),
+            "status_to": new_status,
+        }
+        metrics.manipulate(
+            "sessions_status_changes",
+            "inc",
+            1,
+            manifest_labels=labels,
+            extra_labels=extra_labels
+        )
     api.patch(
         namespace=namespace,
         name=name,
         body={
             "status": {
-                "state": ServerStatusEnum.Stopping.value,
+                "state": new_status,
             },
         },
         content_type=CONTENT_TYPES["merge-patch"],
     )
-    metrics.manipulate("num_of_sessions", "dec", labels)
-    if current_state == ServerStatusEnum.Running.value:
-        metrics.manipulate("num_of_running_sessions", "dec", labels)
-    elif current_state == ServerStatusEnum.Starting.value:
-        metrics.manipulate("num_of_starting_sessions", "dec", labels)
+    metrics.manipulate("sessions_total_deleted", "inc", 1, labels)
 
 
 @kopf.on.field(
@@ -153,22 +167,50 @@ def delete_fn(labels, body, namespace, name, **_):
     config.custom_resource_name,
     field="status.state",
 )
-def state_changed(old, new, labels, logger, **_):
+def state_changed(old, new, labels, body, **_):
     """
     State of the juptyer server status has changed.
     """
-    if new == ServerStatusEnum.Failed.value:
-        metrics.manipulate("total_failed", "inc", labels)
-    elif new == ServerStatusEnum.Running.value:
-        metrics.manipulate("num_of_running_sessions", "inc", labels)
-    elif new == ServerStatusEnum.Stopping.value:
-        # NOTE: When status goes from any to Stopping this is handled in the
-        # delete handler from kopf, not here. This is to avoid double counting.
-        return
-    if old == ServerStatusEnum.Running.value:
-        metrics.manipulate("num_of_running_sessions", "dec", labels)
-    elif old == ServerStatusEnum.Starting.value:
-        metrics.manipulate("num_of_starting_sessions", "dec", labels)
+    if new == ServerStatusEnum.Running.value:
+        start_time = k8s_timestamp_to_utc_datetime(
+            body["metadata"].get("creationTimestamp")
+        )
+        now = pytz.UTC.localize(datetime.utcnow())
+        start_duration = (now - start_time).total_seconds()
+        metrics.manipulate(
+            "sessions_launch_duration",
+            "observe",
+            start_duration,
+            labels,
+        )
+
+    if new == ServerStatusEnum.Starting.value:
+        cpu_request = body.get("spec", {}).get("jupyterServer", {}).get("resources", {})\
+            .get("requests", {}).get("cpu")
+        memory_request = body.get("spec", {}).get("jupyterServer", {}).get("resources", {})\
+            .get("requests", {}).get("memory")
+        disk_request = body.get("spec", {}).get("storage", {}).get("size")
+        if cpu_request:
+            metrics.manipulate(
+                "sessions_cpu_request",
+                "observe",
+                convert_to_millicores(cpu_request),
+                labels,
+            )
+        if memory_request:
+            metrics.manipulate(
+                "sessions_memory_request",
+                "observe",
+                convert_to_bytes(memory_request),
+                labels,
+            )
+        if disk_request:
+            metrics.manipulate(
+                "sessions_disk_request",
+                "observe",
+                convert_to_bytes(disk_request),
+                labels,
+            )
 
 
 @kopf.on.event(
@@ -233,19 +275,42 @@ def update_server_state(body, labels, namespace, **_):
         # If none of the above match the container must be starting
         return ServerStatusEnum.Starting
 
-    status = get_status(body)
+    new_status = get_status(body)
     server_name = labels[config.PARENT_NAME_LABEL_KEY]
     api = get_api(config.api_version, config.custom_resource_name, config.api_group)
-    api.patch(
-        namespace=namespace,
-        name=server_name,
-        body={
-            "status": {
-                "state": status.value,
-            },
-        },
-        content_type=CONTENT_TYPES["merge-patch"],
-    )
+    try:
+        server = api.get(namespace=namespace, name=server_name)
+    except NotFoundError:
+        server = None
+        old_status = None
+    if server:
+        old_status = server.get("status", {}).get("state")
+    # NOTE: Updating the status for deletions is handled in a specific delete handler
+    if old_status != new_status.value and new_status.value != ServerStatusEnum.Stopping.value:
+        try:
+            api.patch(
+                namespace=namespace,
+                name=server_name,
+                body={
+                    "status": {
+                        "state": new_status.value,
+                    },
+                },
+                content_type=CONTENT_TYPES["merge-patch"],
+            )
+        except NotFoundError:
+            pass
+        extra_labels = {
+            "status_from": str(old_status),
+            "status_to": str(new_status.value),
+        }
+        metrics.manipulate(
+            "sessions_status_changes",
+            "inc",
+            1,
+            manifest_labels=labels,
+            extra_labels=extra_labels
+        )
 
 
 @kopf.timer(

--- a/controller/utils.py
+++ b/controller/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from expiringdict import ExpiringDict
 from kubernetes.client.rest import ApiException
 from kubernetes import config as k8s_config, dynamic
@@ -5,6 +6,7 @@ from kubernetes.client import api_client
 from kubernetes.client.api import core_v1_api
 from kubernetes.stream import stream
 import logging
+import pytz
 import re
 
 # A very simple in-memory cache to store the result of the
@@ -210,25 +212,28 @@ def convert_to_bytes(value):
     Convert values from k8s like Ki,K,M,G,Gi etc to bytes
     """
     factors = {
-        None: 1,
-        "K": 1e3,
-        "M": 1e6,
-        "G": 1e9,
-        "T": 1e12,
-        "Ki": 2**10,
-        "Mi": 2**20,
-        "Gi": 2**30,
-        "Ti": 2**40,
+        "K": 1000,
+        "M": 1000**2,
+        "G": 1000**3,
+        "T": 1000**4,
+        "P": 1000**5,
+        "E": 1000**6,
+        "Ki": 1024,
+        "Mi": 1024**2,
+        "Gi": 1024**3,
+        "Ti": 1024**4,
+        "Pi": 1024**5,
+        "Ei": 1024**6,
     }
-    res = re.match(r"^([^\sKMGTi]+)\s*([KMGT][i]*)?$", value.strip())
+    res = re.match(r"^(?<!-)([0-9]*\.?[0-9]*)((?<=[0-9.])[EPTGMKi]*)$", str(value).strip())
     if res is None:
         raise ValueError(f"Cannot convert value {value} to bytes.")
     value, unit = res.groups()
-    if unit not in factors.keys():
+    if unit and unit not in factors.keys():
         raise ValueError(
             f"Cannot convert value {value} to bytes because unit {unit} is not known."
         )
-    return int(float(value)) * factors[unit]
+    return float(value) * (factors[unit] if unit else 1)
 
 
 def convert_to_millicores(value):
@@ -236,19 +241,18 @@ def convert_to_millicores(value):
     Convert values from k8s like 1, 100m, 1000000n etc to millicores
     """
     factors = {
-        None: 1000,
         "m": 1,
         "n": 1e-6,
     }
-    res = re.match(r"^([^\smn]+)\s*([mn]*)?$", value.strip())
+    res = re.match(r"^(?<!-)([0-9]*\.?[0-9]*)([mn]?)$", str(value).strip())
     if res is None:
         raise ValueError(f"Cannot convert value {value} to millicores.")
     value, unit = res.groups()
-    if unit not in factors.keys():
+    if unit and unit not in factors.keys():
         raise ValueError(
             f"Cannot convert value {value} to millicores because unit {unit} is not known."
         )
-    return float(value) * factors[unit]
+    return float(value) * (factors[unit] if unit else 1000)
 
 
 def sanitize_prometheus_metric_label_name(val):
@@ -257,3 +261,13 @@ def sanitize_prometheus_metric_label_name(val):
     val = re.sub(first_letter, "_", val, count=1)
     val = re.sub(all_letters, "_", val)
     return val
+
+
+def k8s_timestamp_to_utc_datetime(timestamp: str) -> datetime:
+    return datetime.fromisoformat(
+        timestamp[:-1] + "+00:00"
+        if timestamp.endswith("Z")
+        else timestamp
+    ).astimezone(
+        pytz.utc
+    )

--- a/controller/utils.py
+++ b/controller/utils.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from expiringdict import ExpiringDict
 from kubernetes.client.rest import ApiException
 from kubernetes import config as k8s_config, dynamic
@@ -6,7 +5,6 @@ from kubernetes.client import api_client
 from kubernetes.client.api import core_v1_api
 from kubernetes.stream import stream
 import logging
-import pytz
 import re
 
 # A very simple in-memory cache to store the result of the
@@ -261,13 +259,3 @@ def sanitize_prometheus_metric_label_name(val):
     val = re.sub(first_letter, "_", val, count=1)
     val = re.sub(all_letters, "_", val)
     return val
-
-
-def k8s_timestamp_to_utc_datetime(timestamp: str) -> datetime:
-    return datetime.fromisoformat(
-        timestamp[:-1] + "+00:00"
-        if timestamp.endswith("Z")
-        else timestamp
-    ).astimezone(
-        pytz.utc
-    )

--- a/helm-chart/amalthea/templates/rbac/_rbac_rules.tpl
+++ b/helm-chart/amalthea/templates/rbac/_rbac_rules.tpl
@@ -7,7 +7,7 @@
   # Amalthea: watching & handling for the custom resource we declare.
   - apiGroups: [{{ .Values.crdApiGroup }}]
     resources: [{{ .Values.crdNames.plural }}]
-    verbs: [list, watch, patch, delete]
+    verbs: [get, list, watch, patch, delete]
 
   - apiGroups: [""]
     resources: [pods]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,6 +27,7 @@ def operator_env(operator_kubeconfig_fp):
     available environment variables that can be overriden."""
     yield {
         "KUBECONFIG": operator_kubeconfig_fp.name,
+        "JUPYTER_SERVER_PENDING_CHECK_INTERVAL_SECONDS": "5",
         "JUPYTER_SERVER_IDLE_CHECK_INTERVAL_SECONDS": "5",
     }
 
@@ -238,14 +239,15 @@ def is_session_ready(k8s_namespace, k8s_amalthea_api):
 
 
 @pytest.fixture
-def is_session_deleted(k8s_namespace, k8s_pod_api):
+def is_session_deleted(k8s_namespace, k8s_pod_api, k8s_amalthea_api):
     def _is_session_deleted(name, timeout_mins=5):
         """Has the session been fully shut down"""
         tstart = datetime.now()
         timeout = timedelta(minutes=timeout_mins)
         while datetime.now() - tstart < timeout:
             pod = find_resource(name + "-0", k8s_namespace, k8s_pod_api)
-            if pod is not None:
+            session = find_resource(name, k8s_namespace, k8s_amalthea_api)
+            if pod is not None or session is not None:
                 sleep(2)
             else:
                 return True

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -286,9 +286,10 @@ def custom_session_manifest(read_manifest, k8s_namespace):
         jupyter_server={"image": "jupyter/minimal-notebook:latest"},
         routing={},
         culling={
-            "idleSecondsThreshold": 30,
-            "startingSecondsThreshold": 90,
-            "failedSecondsThreshold": 90,
+            "idleSecondsThreshold": 0,
+            "startingSecondsThreshold": 0,
+            "failedSecondsThreshold": 0,
+            "maxAgeSecondsThreshold": 0,
         },
         auth={
             "token": "test-auth-token",
@@ -348,3 +349,24 @@ def test_manifest(request, custom_session_manifest):
         manifest_file=request.param["manifest_file"],
         auth=request.param["auth"],
     )
+
+
+@pytest.fixture
+def patch_sleep_init_container():
+    def _patch_sleep_init_container(sleep_duration_seconds):
+        return {
+            "type": "application/json-patch+json",
+            "patch": [
+                {
+                    "op": "add",
+                    "path": "/statefulset/spec/template/spec/initContainers/-",
+                    "value": {
+                        "image": "busybox",
+                        "name": "sleep",
+                        "command": ["sleep"],
+                        "args": [str(sleep_duration_seconds)],
+                    },
+                },
+            ],
+        }
+    yield _patch_sleep_init_container

--- a/tests/integration/test_culling.py
+++ b/tests/integration/test_culling.py
@@ -33,63 +33,64 @@ def test_idle_culling(
     )
 
 
-@pytest.mark.culling
-def test_starting_culling(
-    k8s_namespace,
-    launch_session,
-    is_session_ready,
-    k8s_amalthea_api,
-    k8s_pod_api,
-    test_manifest,
-    is_session_deleted,
-):
-    name = test_manifest["metadata"]["name"]
-    test_manifest["spec"]["jupyterServer"]["resources"] = {"requests": {"cpu": "9000"}}
-    launch_session(test_manifest)
-    assert not is_session_ready(name, timeout_mins=1)
-    session = find_resource(name, k8s_namespace, k8s_amalthea_api)
-    assert session is not None
-    assert session["metadata"]["name"] == name
-    # wait for session to be culled
-    is_session_deleted(
-        name, test_manifest["spec"]["culling"]["startingSecondsThreshold"] + 30
-    )
-    # confirm session got culled
-    session = find_resource(name, k8s_namespace, k8s_amalthea_api)
-    pod = find_resource(name + "-0", k8s_namespace, k8s_pod_api)
-    assert (
-        session is None
-        or pod is None
-        or pod["metadata"].get("deletionTimestamp") is not None
-    )
+# TODO: Fix failed and starting culling and re-enable
+# @pytest.mark.culling
+# def test_starting_culling(
+#     k8s_namespace,
+#     launch_session,
+#     is_session_ready,
+#     k8s_amalthea_api,
+#     k8s_pod_api,
+#     test_manifest,
+#     is_session_deleted,
+# ):
+#     name = test_manifest["metadata"]["name"]
+#     test_manifest["spec"]["jupyterServer"]["resources"] = {"requests": {"cpu": "9000"}}
+#     launch_session(test_manifest)
+#     assert not is_session_ready(name, timeout_mins=1)
+#     session = find_resource(name, k8s_namespace, k8s_amalthea_api)
+#     assert session is not None
+#     assert session["metadata"]["name"] == name
+#     # wait for session to be culled
+#     is_session_deleted(
+#         name, test_manifest["spec"]["culling"]["startingSecondsThreshold"] + 30
+#     )
+#     # confirm session got culled
+#     session = find_resource(name, k8s_namespace, k8s_amalthea_api)
+#     pod = find_resource(name + "-0", k8s_namespace, k8s_pod_api)
+#     assert (
+#         session is None
+#         or pod is None
+#         or pod["metadata"].get("deletionTimestamp") is not None
+#     )
 
 
-@pytest.mark.culling
-def test_failed_culling(
-    k8s_namespace,
-    launch_session,
-    is_session_ready,
-    k8s_amalthea_api,
-    k8s_pod_api,
-    test_manifest,
-    is_session_deleted,
-):
-    name = test_manifest["metadata"]["name"]
-    test_manifest["spec"]["jupyterServer"]["image"] = "nginx:latest"
-    launch_session(test_manifest)
-    assert not is_session_ready(name, timeout_mins=1)
-    session = find_resource(name, k8s_namespace, k8s_amalthea_api)
-    assert session is not None
-    assert session["metadata"]["name"] == name
-    # wait for session to be culled
-    is_session_deleted(
-        name, test_manifest["spec"]["culling"]["failedSecondsThreshold"] + 30
-    )
-    # confirm session got culled
-    session = find_resource(name, k8s_namespace, k8s_amalthea_api)
-    pod = find_resource(name + "-0", k8s_namespace, k8s_pod_api)
-    assert (
-        session is None
-        or pod is None
-        or pod["metadata"].get("deletionTimestamp") is not None
-    )
+# @pytest.mark.culling
+# def test_failed_culling(
+#     k8s_namespace,
+#     launch_session,
+#     is_session_ready,
+#     k8s_amalthea_api,
+#     k8s_pod_api,
+#     test_manifest,
+#     is_session_deleted,
+# ):
+#     name = test_manifest["metadata"]["name"]
+#     test_manifest["spec"]["jupyterServer"]["image"] = "nginx:latest"
+#     launch_session(test_manifest)
+#     assert not is_session_ready(name, timeout_mins=1)
+#     session = find_resource(name, k8s_namespace, k8s_amalthea_api)
+#     assert session is not None
+#     assert session["metadata"]["name"] == name
+#     # wait for session to be culled
+#     is_session_deleted(
+#         name, test_manifest["spec"]["culling"]["failedSecondsThreshold"] + 30
+#     )
+#     # confirm session got culled
+#     session = find_resource(name, k8s_namespace, k8s_amalthea_api)
+#     pod = find_resource(name + "-0", k8s_namespace, k8s_pod_api)
+#     assert (
+#         session is None
+#         or pod is None
+#         or pod["metadata"].get("deletionTimestamp") is not None
+#     )

--- a/tests/integration/test_culling.py
+++ b/tests/integration/test_culling.py
@@ -14,15 +14,19 @@ def test_idle_culling(
     is_session_deleted,
 ):
     name = test_manifest["metadata"]["name"]
+    culling_threshold_seconds = 60
+    test_manifest["spec"]["culling"]["idleSecondsThreshold"] = culling_threshold_seconds
     launch_session(test_manifest)
     assert is_session_ready(name, timeout_mins=5)
     session = find_resource(name, k8s_namespace, k8s_amalthea_api)
+    assert session["spec"]["culling"]["idleSecondsThreshold"] == culling_threshold_seconds
+    assert session["spec"]["culling"]["startingSecondsThreshold"] == 0
+    assert session["spec"]["culling"]["failedSecondsThreshold"] == 0
+    assert session["spec"]["culling"]["maxAgeSecondsThreshold"] == 0
     assert session is not None
     assert session["metadata"]["name"] == name
     # wait for session to be culled
-    is_session_deleted(
-        name, test_manifest["spec"]["culling"]["idleSecondsThreshold"] + 60
-    )
+    is_session_deleted(name, culling_threshold_seconds + 60)
     # confirm session got culled
     session = find_resource(name, k8s_namespace, k8s_amalthea_api)
     pod = find_resource(name + "-0", k8s_namespace, k8s_pod_api)
@@ -33,64 +37,72 @@ def test_idle_culling(
     )
 
 
-# TODO: Fix failed and starting culling and re-enable
-# @pytest.mark.culling
-# def test_starting_culling(
-#     k8s_namespace,
-#     launch_session,
-#     is_session_ready,
-#     k8s_amalthea_api,
-#     k8s_pod_api,
-#     test_manifest,
-#     is_session_deleted,
-# ):
-#     name = test_manifest["metadata"]["name"]
-#     test_manifest["spec"]["jupyterServer"]["resources"] = {"requests": {"cpu": "9000"}}
-#     launch_session(test_manifest)
-#     assert not is_session_ready(name, timeout_mins=1)
-#     session = find_resource(name, k8s_namespace, k8s_amalthea_api)
-#     assert session is not None
-#     assert session["metadata"]["name"] == name
-#     # wait for session to be culled
-#     is_session_deleted(
-#         name, test_manifest["spec"]["culling"]["startingSecondsThreshold"] + 30
-#     )
-#     # confirm session got culled
-#     session = find_resource(name, k8s_namespace, k8s_amalthea_api)
-#     pod = find_resource(name + "-0", k8s_namespace, k8s_pod_api)
-#     assert (
-#         session is None
-#         or pod is None
-#         or pod["metadata"].get("deletionTimestamp") is not None
-#     )
+@pytest.mark.culling
+def test_starting_culling(
+    k8s_namespace,
+    launch_session,
+    is_session_ready,
+    k8s_amalthea_api,
+    k8s_pod_api,
+    test_manifest,
+    is_session_deleted,
+    patch_sleep_init_container,
+):
+    name = test_manifest["metadata"]["name"]
+    culling_threshold_seconds = 60
+    test_manifest["spec"]["culling"]["startingSecondsThreshold"] = culling_threshold_seconds
+    test_manifest["spec"]["patches"] = [patch_sleep_init_container(300)]
+    launch_session(test_manifest)
+    assert not is_session_ready(name, timeout_mins=1)
+    session = find_resource(name, k8s_namespace, k8s_amalthea_api)
+    assert session["spec"]["culling"]["idleSecondsThreshold"] == 0
+    assert session["spec"]["culling"]["startingSecondsThreshold"] == culling_threshold_seconds
+    assert session["spec"]["culling"]["failedSecondsThreshold"] == 0
+    assert session["spec"]["culling"]["maxAgeSecondsThreshold"] == 0
+    assert session is not None
+    assert session["metadata"]["name"] == name
+    # wait for session to be culled
+    is_session_deleted(name, culling_threshold_seconds + 60)
+    # confirm session got culled
+    session = find_resource(name, k8s_namespace, k8s_amalthea_api)
+    pod = find_resource(name + "-0", k8s_namespace, k8s_pod_api)
+    assert (
+        session is None
+        or pod is None
+        or pod["metadata"].get("deletionTimestamp") is not None
+    )
 
 
-# @pytest.mark.culling
-# def test_failed_culling(
-#     k8s_namespace,
-#     launch_session,
-#     is_session_ready,
-#     k8s_amalthea_api,
-#     k8s_pod_api,
-#     test_manifest,
-#     is_session_deleted,
-# ):
-#     name = test_manifest["metadata"]["name"]
-#     test_manifest["spec"]["jupyterServer"]["image"] = "nginx:latest"
-#     launch_session(test_manifest)
-#     assert not is_session_ready(name, timeout_mins=1)
-#     session = find_resource(name, k8s_namespace, k8s_amalthea_api)
-#     assert session is not None
-#     assert session["metadata"]["name"] == name
-#     # wait for session to be culled
-#     is_session_deleted(
-#         name, test_manifest["spec"]["culling"]["failedSecondsThreshold"] + 30
-#     )
-#     # confirm session got culled
-#     session = find_resource(name, k8s_namespace, k8s_amalthea_api)
-#     pod = find_resource(name + "-0", k8s_namespace, k8s_pod_api)
-#     assert (
-#         session is None
-#         or pod is None
-#         or pod["metadata"].get("deletionTimestamp") is not None
-#     )
+@pytest.mark.culling
+def test_failed_culling(
+    k8s_namespace,
+    launch_session,
+    is_session_ready,
+    k8s_amalthea_api,
+    k8s_pod_api,
+    test_manifest,
+    is_session_deleted,
+):
+    name = test_manifest["metadata"]["name"]
+    culling_threshold_seconds = 60
+    test_manifest["spec"]["jupyterServer"]["image"] = "nginx:latest"
+    test_manifest["spec"]["culling"]["failedSecondsThreshold"] = culling_threshold_seconds
+    launch_session(test_manifest)
+    assert not is_session_ready(name, timeout_mins=1)
+    session = find_resource(name, k8s_namespace, k8s_amalthea_api)
+    assert session["spec"]["culling"]["idleSecondsThreshold"] == 0
+    assert session["spec"]["culling"]["startingSecondsThreshold"] == 0
+    assert session["spec"]["culling"]["failedSecondsThreshold"] == culling_threshold_seconds
+    assert session["spec"]["culling"]["maxAgeSecondsThreshold"] == 0
+    assert session is not None
+    assert session["metadata"]["name"] == name
+    # wait for session to be culled
+    is_session_deleted(name, culling_threshold_seconds + 60)
+    # confirm session got culled
+    session = find_resource(name, k8s_namespace, k8s_amalthea_api)
+    pod = find_resource(name + "-0", k8s_namespace, k8s_pod_api)
+    assert (
+        session is None
+        or pod is None
+        or pod["metadata"].get("deletionTimestamp") is not None
+    )

--- a/utils/chart_rbac/__init__.py
+++ b/utils/chart_rbac/__init__.py
@@ -55,7 +55,14 @@ def create_k8s_resources(
     for resource in get_chart_resources(
         amalthea_namespace, server_namespaces, resources, release_name
     ):
-        utils.create_from_dict(k8s_client, resource, namespace=amalthea_namespace)
+        try:
+            utils.create_from_dict(k8s_client, resource, namespace=amalthea_namespace)
+        except utils.FailToCreateError as err:
+            if all([exc.reason == "Conflict" for exc in err.api_exceptions]):
+                # NOTE: All required resources already exist, do not error out
+                pass
+            else:
+                raise
 
 
 def cleanup_k8s_resources(


### PR DESCRIPTION
Modifies the existing metrics from #143 and adds the rest of the metrics that were note initially implemented.

To avoid counting and also therefore potentially double-counting the number of active sessions all such metrics were removed. The number of active sessions can be estimated by looking at the differences between session launches and shutdowns.

If the number of active sessions is tracked then we need some way of tracking which sessions have been counted or not to avoid double counting. Also we need to be able to track when initializing the metric whether the sessions that are initially there have been counted or not.

With https://github.com/SwissDataScienceCenter/renku-notebooks/issues/1069 the proper and long term storage of detailed metrics will be designed and resolved.

closes #156 