### PR TITLE
chore: make unschedulable sessions result in failed status

### DIFF
--- a/controller/server_controller.py
+++ b/controller/server_controller.py
@@ -1,8 +1,8 @@
 import kopf
+from datetime import datetime
 from enum import Enum
 from kubernetes.client.models import V1DeleteOptions
 from kubernetes.dynamic.exceptions import NotFoundError
-from datetime import datetime
 from prometheus_client import start_http_server
 import pytz
 
@@ -201,11 +201,31 @@ def update_server_state(body, labels, namespace, **_):
         ]
         return failed_containers
 
+    def is_pod_unschedulable(pod) -> bool:
+        """Determines is a server pod is unschedulable."""
+        phase = pod.get("status", {}).get("phase")
+        conditions = pod.get("status", {}).get("conditions", [])
+        sorted_conditions = sorted(
+            conditions,
+            key=lambda x: datetime.fromisoformat(x["lastTransitionTime"].rstrip("Z")),
+            reverse=True,
+        )
+        if (
+            phase == "Pending"
+            and len(sorted_conditions) >= 1
+            and sorted_conditions[0].get("reason") == "Unschedulable"
+        ):
+            return True
+        return False
+
     def get_status(pod) -> ServerStatusEnum:
         """Get the status of the jupyterserver."""
         # Is the server terminating?
         if pod["metadata"].get("deletionTimestamp") is not None:
             return ServerStatusEnum.Stopping
+        # Is the pod unschedulable?
+        if is_pod_unschedulable(pod):
+            return ServerStatusEnum.Failed
 
         pod_phase = pod.get("status", {}).get("phase")
         pod_conditions = (


### PR DESCRIPTION
Unschedulable sessions can eventually get scheduled and things will resolve themselves. But in practice we have seen this rarely happen. Therefore instead of introducing a new status for now we will try to use the failed status for unschedulable sessions.

If we see that this is confusing or needs to be changed we can add a new status in the future. It would be nicer and simpler to keep the number of statuses low IMO.