### PR TITLE
fix(app): avoid temporary fail state when starting

### DIFF
--- a/controller/server_controller.py
+++ b/controller/server_controller.py
@@ -212,6 +212,9 @@ def update_server_state(body, labels, namespace, **_):
             phase == "Pending"
             and len(sorted_conditions) >= 1
             and sorted_conditions[0].get("reason") == "Unschedulable"
+            # NOTE: every pod is initially unschedulable until a PV is provisioned
+            # therefore to avoid "flashing" this state when a sessions starts this case is ignored
+            and "persistentvolumeclaim" not in sorted_conditions[0]
         ):
             return True
         return False


### PR DESCRIPTION
The pod that runs the session can (and usually does) get into an unschedulable state for a short period when it is created. This happens just before the PVC is fully provisioned. Because of this the session gets into a failed state for a short period and then goes back to "starting" when the PVC is provisioned.

In order to avoid this case the unschedulable state that occurs because of PVCs not being provisioned is ignored.