### PR TITLE
chore: prep 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.4.0](https://github.com/SwissDataScienceCenter/amalthea/compare/0.3.0...0.4.0)  (2022-06-13)
+
+### Bug Fixes
+
+* **app:** avoid temporary fail state when starting ([#168](https://github.com/SwissDataScienceCenter/amalthea/issues/168)) ([46e0d8d](https://github.com/SwissDataScienceCenter/amalthea/commit/46e0d8d9486c78b6114dd2ab74cadd7da0cb92eb))
+
+
+### Features
+
+* **app:** add and modify prometheus metrics ([#164](https://github.com/SwissDataScienceCenter/amalthea/issues/164)) ([1f34d84](https://github.com/SwissDataScienceCenter/amalthea/commit/1f34d84ab8fcaff7654f149d8e67d4166bf01771))
+* **app:** cull sessions pending too long ([#158](https://github.com/SwissDataScienceCenter/amalthea/issues/158)) ([8fc359e](https://github.com/SwissDataScienceCenter/amalthea/commit/8fc359ea83e9c643b1b7c34b2573c5e829baa35f))
+
+
 ## [0.3.0](https://github.com/SwissDataScienceCenter/amalthea/compare/0.2.3...0.3.0)  (2022-05-16)
 
 ### Bug Fixes

--- a/helm-chart/amalthea/Chart.yaml
+++ b/helm-chart/amalthea/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -4,7 +4,7 @@ charts:
     imagePrefix: renku/
     # An empty tag means that the appVersion specified in Chart.yaml is used.
     resetTag: ""
-    resetVersion: 0.3.0
+    resetVersion: 0.4.0
     repo:
       git: SwissDataScienceCenter/helm-charts
       published: https://swissdatasciencecenter.github.io/helm-charts/


### PR DESCRIPTION
New release - just updates the helm chart version, changelog and chartpress file.