### PR TITLE
chore: add custom CA certificate injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,7 @@ examples-private/
 # Cypress
 acceptance-tests/cypress/screenshots
 acceptance-tests/cypress/videos
+
+# Helm requirements lock files
+helm-chart/amalthea/requirements.lock
+helm-chart/amalthea/Chart.lock

--- a/helm-chart/amalthea/Chart.yaml
+++ b/helm-chart/amalthea/Chart.yaml
@@ -2,6 +2,11 @@ apiVersion: v2
 name: amalthea
 description: A helm chart for deploying the amalthea jupyter server operator
 
+dependencies:
+- name: certificates
+  version: "0.0.2"
+  repository: "https://swissdatasciencecenter.github.io/helm-charts/"
+
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/helm-chart/amalthea/requirements.yaml
+++ b/helm-chart/amalthea/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: certificates
+  version: "0.0.2"
+  repository: "https://swissdatasciencecenter.github.io/helm-charts/"

--- a/helm-chart/amalthea/requirements.yaml
+++ b/helm-chart/amalthea/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: certificates
-  version: "0.0.2"
-  repository: "https://swissdatasciencecenter.github.io/helm-charts/"

--- a/helm-chart/amalthea/templates/deployment.yaml
+++ b/helm-chart/amalthea/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
       serviceAccountName: {{ include "amalthea.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- include "certificates.initContainer" . | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -88,6 +90,7 @@ spec:
               value: {{ .Values.metrics.port | quote }}
             - name: METRICS_EXTRA_LABELS
               value: {{ .Values.metrics.extraMetricsLabels | toJson | quote }}
+            {{- include "certificates.env.python" . | nindent 12 }}
             {{- if .Values.scheduler.enable}}
             - name: SERVER_SCHEDULER_NAME
               value: {{ include "amalthea.fullname" . }}-scheduler
@@ -95,10 +98,12 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /app/config
+            {{- include "certificates.volumeMounts.system" . | nindent 12 }}
       volumes:
         - name: config
           configMap:
             name: {{ include "amalthea.fullname" . }}-config
+        {{- include "certificates.volumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/amalthea/values.schema.json
+++ b/helm-chart/amalthea/values.schema.json
@@ -454,5 +454,5 @@
     ],
     "title": "Values",
     "type": "object",
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -2,6 +2,19 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # Specify a secret that containes the certificate
+  # if you would like to use a custom CA. The key for the secret
+  # should have the .crt extension otherwise it is ignored. The
+  # keys across all secrets are mounted as files in one location so
+  # the keys across all secrets have to be unique.
+  certificates:
+    image:
+      repository: renku/certificates
+      tag: "0.0.1"
+    customCAs: []
+      # - secret:
+
 # Indicate the scope which this operator watches for
 # JupyterServer resources.
 scope:


### PR DESCRIPTION
To properly do idle session culling amalthea needs to send a get request to `https://<ful_session_path>/api/status`.

In cases where self signed certificates are used this would fail without injecting these in amalthea.