### PR TITLE
fix(app): flashing failed status when starting

### DIFF
--- a/controller/config.py
+++ b/controller/config.py
@@ -78,3 +78,13 @@ METRICS_EXTRA_LABELS_SANITIZED = tuple([
     sanitize_prometheus_metric_label_name(i) for i in METRICS_EXTRA_LABELS
 ])
 METRICS_PORT = int(os.environ.get("METRICS_PORT", 8765))
+
+"""How long should a session be unschedulable after it has been created
+before it is marked as failed. All session pods are initially unschedulable for a short duration.
+This occurs mostly because PV provisioning takes time or because of other reasons.
+Therefore, a session should not fail for being unschedulable right after it is created.
+If this is set to zero then the session status usually goes from
+Starting -> Failed (for a few seconds) -> Starting -> Running."""
+UNSCHEDULABLE_FAILURE_THRESHOLD_SECONDS = int(
+    os.environ.get("UNSCHEDULABLE_FAILURE_THRESHOLD_SECONDS", 60)
+)


### PR DESCRIPTION
So it is not that easy to recognize and catch this temporary unschedulable state that commonly occurs when starting.

I though that it is only likely to be related to PV provisioning but this still occurs on some clusters for other reasons. Therefore I think it is best that we simply avoid setting the state to "Failed" for the first 60 seconds after a session's pod is created.

This should avoid this transient fail state and avoid the guessing game of how to exactly recognize it.