### PR TITLE
Fix manifest generation

### DIFF
--- a/.github/workflows/generate-crd-docs.yaml
+++ b/.github/workflows/generate-crd-docs.yaml
@@ -2,8 +2,8 @@ name: Autogenerate the manifests and documentation for the CRD
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   workflow_dispatch:
 
 jobs:
@@ -18,6 +18,7 @@ jobs:
           python -m pip install --upgrade pip pipenv
           pipenv install --dev
           cd helm-chart/
+          helm dep update ./amalthea
           pipenv run chartpress --reset
           cd ../
           pipenv run python utils/render-chart-manifests.py

--- a/.github/workflows/generate-crd-docs.yaml
+++ b/.github/workflows/generate-crd-docs.yaml
@@ -2,8 +2,8 @@ name: Autogenerate the manifests and documentation for the CRD
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Because I added a certificates chart as a dependent for amalthea now the action that updates the rendered amalthea manifests was failing because a simple `helm dep update` was required.

See the passing action here: https://github.com/SwissDataScienceCenter/amalthea/runs/7183741988?check_suite_focus=true

This is the failing action from before: https://github.com/SwissDataScienceCenter/amalthea/runs/7182146311?check_suite_focus=true