### PR TITLE
chore: allow showing hidden files

### DIFF
--- a/controller/templates/configmap.yaml
+++ b/controller/templates/configmap.yaml
@@ -26,6 +26,7 @@ data:
     c.ServerApp.root_dir="{{ jupyter_server["rootDir"] }}"
     c.ServerApp.default_url="{{ jupyter_server["defaultUrl"] }}"
     c.ServerApp.allow_remote_access=True
+    c.ContentsManager.allow_hidden=True
 
   {% if oidc["enabled"] %}
   authorized-users.txt: |

--- a/controller/templates/configmap.yaml
+++ b/controller/templates/configmap.yaml
@@ -14,6 +14,7 @@ data:
     c.NotebookApp.notebook_dir="{{ jupyter_server["rootDir"] }}"
     c.NotebookApp.default_url="{{ jupyter_server["defaultUrl"] }}"
     c.NotebookApp.allow_remote_access=True
+    c.ContentsManager.allow_hidden=True
 
   jupyter_server_config.py: |
     import os


### PR DESCRIPTION
Allow showing hidden files in the JupyterLab file browser.
