### PR TITLE
chore: update oauth2proxy to 7.3.0

### DIFF
--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -148,7 +148,7 @@ spec:
         
         {% if oidc["enabled"] %}
         - name: oauth2-proxy
-          image: "bitnami/oauth2-proxy:7.1.3"
+          image: "bitnami/oauth2-proxy:7.3.0"
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true


### PR DESCRIPTION
It is best to not fall too far behind. This also has some additional/better control over oidc setup and parameters.