### PR TITLE
chore(ci): update cypress action to v4

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -97,11 +97,11 @@ jobs:
           helm dep update helm-chart/amalthea
           helm install amalthea helm-chart/amalthea --wait
       - name: Run Acceptance Tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         env:
           TEST_IMAGE_NAME: ${{ matrix.test-image.image }}
           TEST_SPEC: ${{ matrix.test-image.spec }}
           ENVIRONMENT: ${{ matrix.test-image.env }}
         with:
           working-directory: acceptance-tests
-          command: npx browserslist@latest --update-db && npx mocha test.js
+          command: npx mocha test.js

--- a/acceptance-tests/test.js
+++ b/acceptance-tests/test.js
@@ -85,13 +85,8 @@ EOF`);
     const {stdout, stderr, error} = await exec(`npx cypress run --spec cypress/integration/${testSpec} --env URL=${url}`);
     console.log(`\n\n--------------------------------------------Cypress stdout--------------------------------------------\n${stdout}`)
     console.log(`\n\n--------------------------------------------Cypress stderr--------------------------------------------\n${stderr}`)
-    console.log(`\n\n--------------------------------------------Cypress error--------------------------------------------\n${error}`)
     console.log(`\n\n-----------------------------------------------------------------------------------------------------\n`)
-    if (error || stderr) {
-      console.log(`Something went wrong trying to launch tests.\nError: ${error}\nStderr: ${stderr}\nStdout:${stdout}`)  
-    }
-    assert(!error)
-    assert(!stderr)
+    assert(!error, `Tests failed with error:\n${error}`)
   });
   after(async function () {
     console.log(`Stopping session with image ${image}.`)


### PR DESCRIPTION
I think we may have been having some issues with the last few PRs and the acceptance tests... I am not 100% sure the acceptance tests actually ran.

It is related to this: https://github.com/cypress-io/cypress/issues/19967

Hopefully an update to a new action will fix this.