### PR TITLE
chore(ci): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/acceptance-tests"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I am not sure what defaults dependabot assumes if the file is not there. But is better to have this in code than wonder what is going on.

Also I am not entirely sure that dependabot looked at all of the things it could be looking at (i.e. npm, docker and pip).