### PR TITLE
chore: prep 0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.5.2](https://github.com/SwissDataScienceCenter/amalthea/compare/0.5.1...0.5.2) (2022-08-11)
+
+
+### Bug Fixes
+
+* **metrics:** buckets for prometheus histogram metrics ([#189](https://github.com/SwissDataScienceCenter/amalthea/issues/189)) ([7b34872](https://github.com/SwissDataScienceCenter/amalthea/commit/7b3487207d902919e2934fda7654850d20cdd903))
+* **metrics:** do not publish same metric more than once ([#190](https://github.com/SwissDataScienceCenter/amalthea/issues/190)) ([148d214](https://github.com/SwissDataScienceCenter/amalthea/commit/148d214a01f8ab97008b18c1b1089c481337d047))
+
+
+
 ## [0.5.1](https://github.com/SwissDataScienceCenter/amalthea/compare/0.5.0...0.5.1) (2022-07-22)
 
 

--- a/helm-chart/amalthea/Chart.yaml
+++ b/helm-chart/amalthea/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -4,7 +4,7 @@ charts:
     imagePrefix: renku/
     # An empty tag means that the appVersion specified in Chart.yaml is used.
     resetTag: ""
-    resetVersion: 0.5.1
+    resetVersion: 0.5.2
     repo:
       git: SwissDataScienceCenter/helm-charts
       published: https://swissdatasciencecenter.github.io/helm-charts/


### PR DESCRIPTION
New release. 

The most important update is fixes to the metrics published by Amalthea.