### PR TITLE
fix(app): do not use previous status for state

### DIFF
--- a/controller/config.py
+++ b/controller/config.py
@@ -74,3 +74,7 @@ MAIN_POD_LABEL_KEY = f"{api_group}/main-pod"
 
 METRICS: PrometheusMetricsConfig = PrometheusMetricsConfig.dataconf_from_env()
 AUDITLOG: AuditlogConfig = AuditlogConfig.dataconf_from_env()
+
+JUPYTER_SERVER_INIT_CONTAINER_RESTART_LIMIT: int = int(
+    os.environ.get("JUPYTER_SERVER_INIT_CONTAINER_RESTART_LIMIT", 1)
+)


### PR DESCRIPTION
I think when I added this (originally to the notebook service) I misunderstood what "lastState" meant. 

What it truly means is that when a container is for example killed for consuming too much memory, then the last state will show "OOMKilled" as the reason and it will show the last exit code.

So with the old logic when a container was "OOMKilled" (i.e. restarted for consuming memory above its limit) then it would have it's last state as that. And the logic for the container state would be stuck on "failing" even though the new current state is all good and the whole sessions is functioning normally.

fixes https://github.com/SwissDataScienceCenter/renku-notebooks/issues/1225