### PR TITLE
fix: check url when setting status

### DIFF
--- a/controller/config.py
+++ b/controller/config.py
@@ -78,3 +78,6 @@ AUDITLOG: AuditlogConfig = AuditlogConfig.dataconf_from_env()
 JUPYTER_SERVER_INIT_CONTAINER_RESTART_LIMIT: int = int(
     os.environ.get("JUPYTER_SERVER_INIT_CONTAINER_RESTART_LIMIT", 1)
 )
+JUPYTER_SERVER_CONTAINER_RESTART_LIMIT: int = int(
+    os.environ.get("JUPYTER_SERVER_CONTAINER_RESTART_LIMIT", 5)
+)

--- a/controller/k8s_resources.py
+++ b/controller/k8s_resources.py
@@ -68,8 +68,8 @@ def create_template_values(name, spec):
         "name": name,
         "oidc": spec["auth"]["oidc"],
         "path": os.path.join("/", spec["routing"]["path"].rstrip("/")),
-        "probe_path": os.path.join(
-            "/", spec["routing"]["path"].rstrip("/"), "api/status"
+        "probe_path": urljoin(
+            spec["routing"]["path"] + "/", "api/status"
         ),
         "pvc": spec["storage"]["pvc"],
         "routing": spec["routing"],

--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -118,9 +118,8 @@ spec:
                 - name: Authorization
                   value: {{ "token " ~ jupyter_server_app_token }}
               {% endif %}
-            periodSeconds: 10
-            failureThreshold: 6
-            timeoutSeconds: 9
+            periodSeconds: 2
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: {{ probe_path }}
@@ -130,9 +129,9 @@ spec:
                 - name: Authorization
                   value: {{ "token " ~ jupyter_server_app_token }}
               {% endif %}
-            periodSeconds: 10
-            failureThreshold: 2
-            timeoutSeconds: 9
+            periodSeconds: 2
+            failureThreshold: 10
+            successThreshold: 2
           startupProbe:
             httpGet:
               path: {{ probe_path }}
@@ -142,9 +141,10 @@ spec:
                 - name: Authorization
                   value: {{ "token " ~ jupyter_server_app_token }}
               {% endif %}
-            periodSeconds: 10
-            failureThreshold: 30
-            timeoutSeconds: 9
+            # NOTE: if the startup probe does not succeed within periodSeconds X failureThreshold
+            # Then the container is killed and restarted according to the pod's restartPolicy
+            periodSeconds: 2
+            failureThreshold: 150
         
         {% if oidc["enabled"] %}
         - name: oauth2-proxy
@@ -201,6 +201,25 @@ spec:
             limits:
               cpu: 100m
               memory: 32Mi
+          livenessProbe:
+            httpGet:
+              port: 4180
+              path: /ping
+            periodSeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              port: 4180
+              path: /ping
+            periodSeconds: 2
+            failureThreshold: 30
+            successThreshold: 2
+          startupProbe:
+            httpGet:
+              port: 4180
+              path: /ping
+            periodSeconds: 2
+            failureThreshold: 150
         {% else %}
         - name: passthrough-proxy
           image: traefik:v2.5
@@ -212,6 +231,7 @@ spec:
           args:
            - --entryPoints.web.address=:4180
            - --providers.file.directory=/traefik
+           - --ping.entryPoint=web
           ports:
             - name: http
               containerPort: 4180
@@ -227,4 +247,23 @@ spec:
             limits:
               cpu: 100m
               memory: 64Mi
+          livenessProbe:
+            httpGet:
+              port: 4180
+              path: /ping
+            periodSeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              port: 4180
+              path: /ping
+            periodSeconds: 2
+            failureThreshold: 30
+            successThreshold: 2
+          startupProbe:
+            httpGet:
+              port: 4180
+              path: /ping
+            periodSeconds: 2
+            failureThreshold: 150
         {% endif %}

--- a/controller/utils.py
+++ b/controller/utils.py
@@ -25,7 +25,8 @@ def get_pod_metrics(pod_name, namespace):
         )
     except ApiException as err:
         logging.warning(
-            f"Could not get metrics for pod {pod_name} in namespace {namespace}, because: {err}"
+            f"Could not get metrics for pod {pod_name} "
+            f"in namespace {namespace}, because: {type(err)}"
         )
         return None
 


### PR DESCRIPTION
It can happen that even when all k8s statuses and states are good and the session is marked as "Running" that the service/ingress are still not fully synced. And accessing the server at this time results in a 503 just as if you had accessed the server before the readiness probes all cleared.

I tried many different ways to avoid this but I would always (one way or another) end up with a 503 screen even though the state is running. 

Therefore now I do a GET request to the session URL when I think the server is ready. And if this GET request suceeds the server is marked as ready. If not the request is retried several times before the sessions is marked as "failed". 