### PR TITLE
feat(chart): refactor additional namespaces setup

### DIFF
--- a/helm-chart/amalthea/templates/deployment.yaml
+++ b/helm-chart/amalthea/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             {{- if .Values.scope.clusterWide }}
             - "--all-namespaces"
             {{- else }}
-            {{- range (.Values.scope.namespaces | default (list .Release.Namespace)) }}
+            {{- range (append .Values.scope.additionalNamespaces .Release.Namespace | uniq) }}
             - "--namespace={{ . }}"
             {{- end }}
             {{- end }}

--- a/helm-chart/amalthea/templates/networkpolicies.yaml
+++ b/helm-chart/amalthea/templates/networkpolicies.yaml
@@ -23,7 +23,7 @@ spec:
           port: {{ .Values.metrics.port }}
   {{- end }}
 {{ if and .Values.networkPolicies.enabled ( not .Values.scope.clusterWide ) }}
-{{- range (.Values.scope.namespaces | default (list .Release.Namespace)) -}}
+{{- range (append .Values.scope.additionalNamespaces .Release.Namespace | uniq) -}}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/helm-chart/amalthea/templates/rbac/rbac-namespaced.yaml
+++ b/helm-chart/amalthea/templates/rbac/rbac-namespaced.yaml
@@ -4,7 +4,7 @@
 {{- /* We store the full scope because . is overwritten when in the loop. */}}
 {{- $fullTemplateScope := . }}
 
-{{- range (.Values.scope.namespaces | default (list .Release.Namespace)) }}
+{{- range (append .Values.scope.additionalNamespaces .Release.Namespace | uniq) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm-chart/amalthea/values.schema.json
+++ b/helm-chart/amalthea/values.schema.json
@@ -23,9 +23,9 @@
                             "clusterWide": {
                                 "const": false
                             },
-                            "namespaces": {
+                            "additionalNamespaces": {
                                 "type": "array",
-                                "minItems": 1,
+                                "minItems": 0,
                                 "items": [
                                     {
                                         "type": "string"
@@ -35,8 +35,7 @@
                             }
                         },
                         "required": [
-                            "clusterWide",
-                            "namespaces"
+                            "clusterWide"
                         ],
                         "additionalProperties": false
                     },

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -27,12 +27,11 @@ scope:
   #    cluster-wide deployments and admins will need to set up appropriate
   #    network policies manually.
   clusterWide: false
-  # Namespaces should not be provided if clusterWide is true.
-  # If the deployment is not clusterwide, then there are two options:
-  # 1. Specify the namespaces where amalthea should operate
-  # 2. Do not define namespaces at all, in which case amalthea
-  #    will only operate in the namespace where the helm chart is deployed.
-  # namespaces: ["default"]
+  # additionalNamespaces is used only if clusterWide is false.
+  # If the deployment is not clusterwide, then this is a list of namespaces
+  # where amalthea will operate in addition to the namespace where the helm chart
+  # is deployed and the amalthea deployment is running.
+  additionalNamespaces: []
 
 deployCrd: true # whether to deploy the jupyterserver CRD
 


### PR DESCRIPTION
This changes the meaning of the "namespaces" value in the values files.

The original meaning is that if amalthea can be deployed either in "cluster" mode or namespaced. In cluster mode amalthea gets a clusterrole and it can create servers anywhere. In namespaced mode we allow several namespaces to be defined and we create the required resources in each namespace. The values file is setup such that if the `.Values.scope.namespaces` field is undefined then amalthea has permissions to create servers only in the namespace where it is deployed. But if this value is specified then amalthea has permissions in the namespace where the helm chart is deployed and any namespaces from the list in the values file. This is slightly cumbersome because we have to keep the field undefined to get the default and then define it to get additional namespaces.

Now I changed this field so that it is called `additionalNamespaces`. This is now defined and its default value in the values file is an empty list. And if left like that then amalthea has permissions only for the namespace where the helm chart is deployed. But if values are added to the `additionalNamespaces` field then amalthea has access to these namespaces in addtion to the namespace where the helm chart is deployed.

I think this makes things easier because we can now specify additional namespaces without bothering to include the helm chart namespace in the list. Before this if we wanted to give amalthea permissions to the namespace where the helm chart is deployed and 2 more we would have to list the namespace where the helm chart is deployed in this list in the values file. This is redundant and weird because this is not usually done. The helm chart knows and can access the value of the namespace where it will be deployed so it should not be specified in the values file.