### PR TITLE
fix(app): consider idle when connections are < 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,5 @@ acceptance-tests/cypress/videos
 # Helm requirements lock files
 helm-chart/amalthea/requirements.lock
 helm-chart/amalthea/Chart.lock
+
+__pycache__

--- a/controller/server_controller.py
+++ b/controller/server_controller.py
@@ -246,7 +246,7 @@ def cull_idle_jupyter_servers(body, name, namespace, logger, **kwargs):
     jupyter_server_is_idle_now = (
         cpu_usage <= config.CPU_USAGE_MILLICORES_IDLE_THRESHOLD
         and type(js_server_status) is dict
-        and js_server_status.get("connections", 0) == 0
+        and js_server_status.get("connections", 0) <= 0
         and last_activity_age_seconds
         > config.JUPYTER_SERVER_IDLE_CHECK_INTERVAL_SECONDS
     )


### PR DESCRIPTION
We seem to have some sessions that never get culled that show this type of "activity" as published by jupyter lab:

```
Normal  Logging  12m   kopf  Timer 'cull_idle_jupyter_servers' succeeded.
  Normal  Logging  8m5s  kopf  Timer 'cull_pending_jupyter_servers' succeeded.
  Normal  Logging  7m1s  kopf  Timer 'cull_idle_jupyter_servers' succeeded.
  Normal  Logging  7m1s  kopf  Checking idle status of session lorena-2eb-hs22-0bfa3903, idle seconds: 0, cpu usage: 37.767173m, server status: {'connections': -2, 'kernels': 1, 'last_activity': datetime.datetime(2022, 11, 18, 16, 31, 16, 185075, tzinfo=tzutc()), 'started': datetime.datetime(2022, 11, 15, 15, 1, 27, 848584, tzinfo=tzutc())}, age: 6568507.59917 seconds
  Normal  Logging  3m5s  kopf  Timer 'cull_pending_jupyter_servers' succeeded.
  Normal  Logging  2m1s  kopf  Checking idle status of session lorena-2eb-hs22-0bfa3903, idle seconds: 0, cpu usage: 40.29112799999999m, server status: {'connections': -2, 'kernels': 1, 'last_activity': datetime.datetime(2022, 11, 18, 16, 31, 16, 185075, tzinfo=tzutc()), 'started': datetime.datetime(2022, 11, 15, 15, 1, 27, 848584, tzinfo=tzutc())}, age: 6568807.724319 seconds
  Normal  Logging  2m1s  kopf  Timer 'cull_idle_jupyter_servers' succeeded.
```

We use number of connections `==0` as one of the conditions for idleness. And because the values go negative we have sessions that are never culled.

This should fix that. We still rely on the `last_activity` field in the jupyter lab status so even if assuming that connections <0 are idle is too aggressive we still in addition rely on last activity which should prevent us from prematurely culling sessions.