### PR TITLE
chore: do not log healthchecks in oauth2 proxy

### DIFF
--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -165,6 +165,7 @@ spec:
             - "--proxy-prefix={{ path if path != '/' else '' }}/oauth2"
             - "--authenticated-emails-file=/etc/oauth2-proxy/authorized-users.txt"
             - "--skip-auth-route=^{{ path if path != '/' else '' }}/api/status$"
+            - "--exclude-logging-path=/ping"
             {% for group in oidc["authorizedGroups"] %}
             - "--allowed-group={{ group }}"
             {% endfor %}


### PR DESCRIPTION
The logs contain a lot of chatter from logging access to the health checks.

This option removes that.