### PR TITLE
chore: update oauth2 proxy to 7.4.0

### DIFF
--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -148,7 +148,7 @@ spec:
         
         {% if oidc["enabled"] %}
         - name: oauth2-proxy
-          image: "bitnami/oauth2-proxy:7.3.0"
+          image: "bitnami/oauth2-proxy:7.4.0"
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true


### PR DESCRIPTION
This should address https://github.com/SwissDataScienceCenter/renku-notebooks/issues/1510

Simply from the logs of 7.4.0 and 7.3.0 you can see that in 7.3.0 the watcher reloads all the time:

Log with 7.3.0
```
[2023/07/13 11:56:57] [validator.go:28] using authenticated emails file /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:56:57] [watcher.go:80] watching /etc/oauth2-proxy/authorized-users.txt for updates
[2023/07/13 11:56:57] [provider.go:55] Performing OIDC Discovery...
[2023/07/13 11:56:57] [providers.go:145] Warning: Your provider supports PKCE methods ["plain" "S256"], but you have not enabled one with --code-challenge-method
[2023/07/13 11:56:57] [proxy.go:89] mapping path "/sessions/tasko-2eol-test-2d17-5687dfbe/sidecar/" => upstream "http://127.0.0.1:4000/sessions/tasko-2eol-test-2d17-5687dfbe/sidecar/"
[2023/07/13 11:56:57] [proxy.go:89] mapping path "/sessions/tasko-2eol-test-2d17-5687dfbe/" => upstream "http://127.0.0.1:8888/sessions/tasko-2eol-test-2d17-5687dfbe/"
[2023/07/13 11:56:57] [oauthproxy.go:146] Skipping JWT tokens from configured OIDC issuer: "https://dev.renku.ch/auth/realms/Renku"
[2023/07/13 11:56:57] [oauthproxy.go:156] OAuthProxy configured for OpenID Connect Client ID: renku-jupyterserver
[2023/07/13 11:56:57] [oauthproxy.go:162] Cookie settings: name:_oauth2_proxy secure(https):true httponly:true expiry:168h0m0s domains: path:/sessions/tasko-2eol-test-2d17-5687dfbe samesite: refresh:disabled
[2023/07/13 11:56:57] [oauthproxy.go:463] Skipping auth - Method:  | Path: ^/sessions/tasko-2eol-test-2d17-5687dfbe/api/status$
[2023/07/13 11:56:57] [oauthproxy.go:463] Skipping auth - Method:  | Path: ^/sessions/tasko-2eol-test-2d17-5687dfbe/sidecar/health$
[2023/07/13 11:56:57] [oauthproxy.go:463] Skipping auth - Method:  | Path: ^/sessions/tasko-2eol-test-2d17-5687dfbe/sidecar/health/$
[2023/07/13 11:56:57] [oauthproxy.go:463] Skipping auth - Method:  | Path: ^/sessions/tasko-2eol-test-2d17-5687dfbe/sidecar/jsonrpc/map$
[2023/07/13 11:57:00] [watcher.go:63] watching interrupted on event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:00] [watcher.go:29] watching resumed for /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:57:00] [watcher.go:70] reloading after event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
192.168.0.151:51054 - 75e635d3-c313-426c-929a-c30ce5a3adae - - [2023/07/13 11:57:00] 10.42.5.188:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
192.168.0.151:51066 - 028a30f2-3dc2-44d0-acbc-aec8f28a32d4 - - [2023/07/13 11:57:00] 10.42.5.188:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
[2023/07/13 11:57:01] [watcher.go:63] watching interrupted on event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:01] [watcher.go:29] watching resumed for /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:57:01] [watcher.go:70] reloading after event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
192.168.0.151:51068 - 04e22b1b-9e82-453e-b792-1e7809ba306a - - [2023/07/13 11:57:01] 10.42.5.188:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
[2023/07/13 11:57:02] [watcher.go:63] watching interrupted on event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:02] [watcher.go:29] watching resumed for /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:57:02] [watcher.go:70] reloading after event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
192.168.0.151:51070 - c59fcf2e-5f40-4225-be23-3757d9915caf - - [2023/07/13 11:57:02] 10.42.5.188:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
[2023/07/13 11:57:03] [watcher.go:63] watching interrupted on event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:03] [watcher.go:29] watching resumed for /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:57:03] [watcher.go:70] reloading after event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:04] [watcher.go:63] watching interrupted on event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:04] [watcher.go:29] watching resumed for /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:57:04] [watcher.go:70] reloading after event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
192.168.0.151:51080 - ce545a95-f3c3-453b-a920-e0381799eb28 - - [2023/07/13 11:57:04] 10.42.5.188:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
192.168.0.151:57100 - 2ec317d9-2263-420f-b79c-e684b17edcf9 - - [2023/07/13 11:57:06] 10.42.5.188:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
192.168.0.151:57126 - eded9855-93a7-4427-b817-9aa7ec80f4ec - - [2023/07/13 11:57:08] 10.42.5.188:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
192.168.0.151:57110 - 79b960a3-539e-4edb-b611-bfd1905ccc17 - - [2023/07/13 11:57:08] 10.42.5.188:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
[2023/07/13 11:57:08] [watcher.go:63] watching interrupted on event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:08] [watcher.go:29] watching resumed for /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:57:08] [watcher.go:70] reloading after event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:09] [watcher.go:63] watching interrupted on event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:09] [watcher.go:29] watching resumed for /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:57:09] [watcher.go:70] reloading after event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
192.168.0.151:57142 - 5704a9fb-0089-41c2-8d4b-3793b65daf39 - - [2023/07/13 11:57:10] 10.42.5.188:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
[2023/07/13 11:57:10] [watcher.go:63] watching interrupted on event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:10] [watcher.go:29] watching resumed for /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:57:10] [watcher.go:70] reloading after event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:11] [watcher.go:63] watching interrupted on event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:11] [watcher.go:29] watching resumed for /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:57:11] [watcher.go:70] reloading after event: "/etc/oauth2-proxy/authorized-users.txt": CHMOD
[2023/07/13 11:57:12] [oauthproxy.go:904] No valid authentication in request. Initiating login.
```

Whereas with 7.4.0 no reloads happen:
```
2023/07/13 11:55:01] [validator.go:29] using authenticated emails file /etc/oauth2-proxy/authorized-users.txt
[2023/07/13 11:55:01] [watcher.go:40] watching '/etc/oauth2-proxy/authorized-users.txt' for updates
[2023/07/13 11:55:01] [provider.go:55] Performing OIDC Discovery...
[2023/07/13 11:55:01] [providers.go:145] Warning: Your provider supports PKCE methods ["plain" "S256"], but you have not enabled one with --code-challenge-method
[2023/07/13 11:55:01] [proxy.go:89] mapping path "/sessions/tasko-2eol-test-2d18-8242c668/sidecar/" => upstream "http://127.0.0.1:4000/sessions/tasko-2eol-test-2d18-8242c668/sidecar/"
[2023/07/13 11:55:01] [proxy.go:89] mapping path "/sessions/tasko-2eol-test-2d18-8242c668/" => upstream "http://127.0.0.1:8888/sessions/tasko-2eol-test-2d18-8242c668/"
[2023/07/13 11:55:01] [oauthproxy.go:152] Skipping JWT tokens from configured OIDC issuer: "https://dev.renku.ch/auth/realms/Renku"
[2023/07/13 11:55:01] [oauthproxy.go:162] OAuthProxy configured for OpenID Connect Client ID: renku-jupyterserver
[2023/07/13 11:55:01] [oauthproxy.go:168] Cookie settings: name:_oauth2_proxy secure(https):true httponly:true expiry:168h0m0s domains: path:/sessions/tasko-2eol-test-2d18-8242c668 samesite: refresh:disabled
[2023/07/13 11:55:01] [oauthproxy.go:476] Skipping auth - Method:  | Path: ^/sessions/tasko-2eol-test-2d18-8242c668/api/status$
[2023/07/13 11:55:01] [oauthproxy.go:476] Skipping auth - Method:  | Path: ^/sessions/tasko-2eol-test-2d18-8242c668/sidecar/health$
[2023/07/13 11:55:01] [oauthproxy.go:476] Skipping auth - Method:  | Path: ^/sessions/tasko-2eol-test-2d18-8242c668/sidecar/health/$
[2023/07/13 11:55:01] [oauthproxy.go:476] Skipping auth - Method:  | Path: ^/sessions/tasko-2eol-test-2d18-8242c668/sidecar/jsonrpc/map$
192.168.0.151:51534 - 5fad2d9f-ffd2-4b4f-b615-90451eb5f36b - - [2023/07/13 11:55:03] 10.42.5.187:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
192.168.0.151:51546 - fbd65568-8d69-4cd2-ab76-86983703cd39 - - [2023/07/13 11:55:03] 10.42.5.187:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
192.168.0.151:51558 - b9165d00-55ba-41be-be66-c9988fe9f26d - - [2023/07/13 11:55:04] 10.42.5.187:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
192.168.0.151:44546 - 1e9bc1e6-a28a-4c67-8ed4-47808d109bb7 - - [2023/07/13 11:55:05] 10.42.5.187:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
192.168.0.151:44532 - 1957a555-5a41-442d-9f36-b6d8d0c6556b - - [2023/07/13 11:55:05] 10.42.5.187:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
192.168.0.151:44558 - 6d3ce975-5ff9-4d1d-b204-39a52b6c0a6b - - [2023/07/13 11:55:07] 10.42.5.187:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
[2023/07/13 11:55:08] [oauthproxy.go:959] No valid authentication in request. Initiating login.
10.42.8.10:41294 - f5b28d3aaa3868d516a0d53fb827896a - - [2023/07/13 11:55:08] dev.renku.ch GET - "/sessions/tasko-2eol-test-2d18-8242c668" HTTP/1.1 "python-requests/2.31.0" 302 407 0.001
192.168.0.151:44570 - 1c3979dc-f85f-4f46-b8bb-3fcc95397a4c - - [2023/07/13 11:55:09] 10.42.5.187:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
[2023/07/13 11:55:09] [oauthproxy.go:959] No valid authentication in request. Initiating login.
10.42.10.59:36626 - 155aa8329ddeac835a63b3273d2ca9d2 - - [2023/07/13 11:55:09] dev.renku.ch GET - "/sessions/tasko-2eol-test-2d18-8242c668" HTTP/1.1 "python-requests/2.31.0" 302 407 0.000
[2023/07/13 11:55:09] [oauthproxy.go:959] No valid authentication in request. Initiating login.
10.42.33.187:52516 - 3648ebff677eadfd2d139a03323de540 - - [2023/07/13 11:55:09] dev.renku.ch GET - "/sessions/tasko-2eol-test-2d18-8242c668" HTTP/1.1 "python-requests/2.31.0" 302 407 0.000
10.42.14.152:51470 - 13705c546bb699854087180772789cb0 - tasko.olevski@sdsc.ethz.ch [2023/07/13 11:55:10] dev.renku.ch GET /sessions/tasko-2eol-test-2d18-8242c668/ "/sessions/tasko-2eol-test-2d18-8242c668/" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 302 0 0.003
10.42.14.152:51470 - a0b1384e8558ff5e4ecf8672e5ca4e6c - tasko.olevski@sdsc.ethz.ch [2023/07/13 11:55:10] dev.renku.ch GET /sessions/tasko-2eol-test-2d18-8242c668/ "/sessions/tasko-2eol-test-2d18-8242c668/lab?" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 304 0 0.017
10.42.14.152:51470 - 3a10c29ac8f2d21a5c88c71835351d99 - tasko.olevski@sdsc.ethz.ch [2023/07/13 11:55:10] dev.renku.ch GET /sessions/tasko-2eol-test-2d18-8242c668/ "/sessions/tasko-2eol-test-2d18-8242c668/lab/extensions/jupyterlab_pygments/static/remoteEntry.aa1060b2d1221f8e5688.js" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 304 0 0.005
10.42.14.152:51474 - 0ece531a4ebd1b083a34711c42417d97 - tasko.olevski@sdsc.ethz.ch [2023/07/13 11:55:10] dev.renku.ch GET /sessions/tasko-2eol-test-2d18-8242c668/ "/sessions/tasko-2eol-test-2d18-8242c668/lab/extensions/nbdime-jupyterlab/static/remoteEntry.7dd115740677e3b366fe.js" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 304 0 0.007
10.42.14.152:51474 - 2cf2f5094befbcb616ff52780b0c1830 - tasko.olevski@sdsc.ethz.ch [2023/07/13 11:55:10] dev.renku.ch GET /sessions/tasko-2eol-test-2d18-8242c668/ "/sessions/tasko-2eol-test-2d18-8242c668/lab/extensions/jupyterlab-topbar-extension/static/remoteEntry.d1b2608380b59cf07890.js" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 304 0 0.003
10.42.14.152:51470 - 2e5d7ed837111a509de21525b81e12f3 - tasko.olevski@sdsc.ethz.ch [2023/07/13 11:55:10] dev.renku.ch GET /sessions/tasko-2eol-test-2d18-8242c668/ "/sessions/tasko-2eol-test-2d18-8242c668/lab/extensions/jupyterlab-system-monitor/static/remoteEntry.961e4f7107573a8ce772.js" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 304 0 0.003
10.42.14.152:51470 - 40ec57bef71f3c936c082b3607ac501e - tasko.olevski@sdsc.ethz.ch [2023/07/13 11:55:10] dev.renku.ch GET /sessions/tasko-2eol-test-2d18-8242c668/ "/sessions/tasko-2eol-test-2d18-8242c668/lab/extensions/@jupyterlab/git/static/remoteEntry.4318d00d399dc15e3535.js" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 304 0 0.003
10.42.14.152:51474 - dfe51f42a27a3676256e4a731c6097b0 - tasko.olevski@sdsc.ethz.ch [2023/07/13 11:55:10] dev.renku.ch GET /sessions/tasko-2eol-test-2d18-8242c668/ "/sessions/tasko-2eol-test-2d18-8242c668/lab/extensions/@jupyter-server/resource-usage/static/remoteEntry.fd0401d26424daec88e3.js" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 304 0 0.005
10.42.14.152:51470 - 7fc6e5bcc0d413e107641ebdefee1b2b - tasko.olevski@sdsc.ethz.ch [2023/07/13 11:55:10] dev.renku.ch GET /sessions/tasko-2eol-test-2d18-8242c668/ "/sessions/tasko-2eol-test-2d18-8242c668/lab/extensions/@jupyterhub/jupyter-server-proxy/static/remoteEntry.6bef4394de3b3e455a6a.js" HTTP/1.1 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36" 304 0 0.006
192.168.0.151:44584 - 4a23e189-a1dc-483f-8967-0118fe22ea6f - - [2023/07/13 11:55:11] 10.42.5.187:4180 GET - "/ping" HTTP/1.1 "kube-probe/1.24" 200 2 0.000
```

closes https://github.com/SwissDataScienceCenter/renku-notebooks/issues/1510