### PR TITLE
chore: prep 0.7.1. release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.7.1](https://github.com/SwissDataScienceCenter/amalthea/compare/0.7.0...0.7.1) (2023-07-18)
+
+### Bug Fixes
+
+* **app:** upgrade OAuth2 proxy to 7.4.0 to prevent unnecessary proxy restarting ([#341](https://github.com/SwissDataScienceCenter/amalthea/issues/341)) ([091909f](https://github.com/SwissDataScienceCenter/amalthea/commit/091909fde471992c007141db842988b1234a7aea))
+
 ## [0.7.0](https://github.com/SwissDataScienceCenter/amalthea/compare/0.6.1...0.7.0) (2023-06-27)
 
 ### Features

--- a/helm-chart/amalthea/Chart.yaml
+++ b/helm-chart/amalthea/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/chartpress.yaml
+++ b/helm-chart/chartpress.yaml
@@ -4,7 +4,7 @@ charts:
     imagePrefix: renku/
     # An empty tag means that the appVersion specified in Chart.yaml is used.
     resetTag: ""
-    resetVersion: 0.7.0
+    resetVersion: 0.7.1
     repo:
       git: SwissDataScienceCenter/helm-charts
       published: https://swissdatasciencecenter.github.io/helm-charts/


### PR DESCRIPTION
New release with a minor bug fix for the restarting oauth2 proxy.