### PR TITLE
feat: remove path prefix

### DIFF
--- a/controller/templates/configmap.yaml
+++ b/controller/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
     c.NotebookApp.token=os.environ["SERVER_APP_TOKEN"]
     c.NotebookApp.cookie_secret_file="/etc/jupyter_server_secrets/cookie_secret"
     c.NotebookApp.allow_origin="{{ host_url }}"
-    c.NotebookApp.base_url="{{ path }}"
+    c.NotebookApp.base_url="/"
     c.NotebookApp.notebook_dir="{{ jupyter_server["rootDir"] }}"
     c.NotebookApp.default_url="{{ jupyter_server["defaultUrl"] }}"
     c.NotebookApp.allow_remote_access=True
@@ -23,7 +23,7 @@ data:
     c.ServerApp.token=os.environ["SERVER_APP_TOKEN"]
     c.ServerApp.cookie_secret_file="/etc/jupyter_server_secrets/cookie_secret"
     c.ServerApp.allow_origin="{{ host_url }}"
-    c.ServerApp.base_url="{{ path }}"
+    c.ServerApp.base_url="/"
     c.ServerApp.root_dir="{{ jupyter_server["rootDir"] }}"
     c.ServerApp.default_url="{{ jupyter_server["defaultUrl"] }}"
     c.ServerApp.allow_remote_access=True
@@ -37,13 +37,20 @@ data:
   {% else %}
   traefik-dynamic-config.yaml: |
     http:
+      middlewares:
+        removePrefix:
+          stripPrefix:
+            prefixes:
+              - "{{ path }}"
       routers:
         to-passthrough:
           rule: "PathPrefix(`/`)"
           service: passthrough
+          middlewares:
+            - removePrefix
       services:
         passthrough:
           loadBalancer:
             servers:
-            - url: http://localhost:8888
+              - url: http://localhost:8888
   {% endif %}

--- a/controller/templates/secret.yaml
+++ b/controller/templates/secret.yaml
@@ -8,9 +8,29 @@ data:
   jupyterServerCookieSecret: {{ jupyter_server_cookie_secret | b64encode }}
 
   {% if auth["oidc"]["enabled"] %}
-  {% if "value" in auth["oidc"]["clientSecret"] %}
-  oidcClientSecret: {{ oidc["clientSecret"]["value"] | b64encode }}
-  {% endif %}
   oauth2ProxyCookieSecret: {{ authentication_plugin_cookie_secret | b64encode }}
+  oauth2ProxyConfig.yaml: |
+    upstreams:
+      - id: application
+        path: "{{ path.rstrip("/") }}/(.*)"
+        rewriteTarget: "/$1"
+        uri: http://127.0.0.1:8888
+        insecureSkipTLSVerify: true
+        proxyWebSockets: true
+    providers:
+      - provider: oidc
+        {% if "value" in auth["oidc"]["clientSecret"] %}
+        clientSecret: {{ oidc["clientSecret"]["value"] }}
+        {% elif "secretKeyRef" in auth["oidc"]["clientSecret"] %}
+        clientSecretFile: /etc/oauth2-proxy/oidc-client-secret/{{ auth["oidc"]["clientSecret"]["secretKeyRef"]["key"] }}
+        {% endif %}
+        clientID: {{ oidc["clientId"] }}
+        oidcConfig:
+          oidcIssuerURL: {{ oidc["issuerUrl"] }}
+        {% if oidc["authorizedGroups"] | length > 0 %}
+        allowedGroups:
+        {% for group in oidc["authorizedGroups"] %}
+          - "{{ group }}"
+        {% endfor %}
+        {% endif %}
   {% endif %}
-

--- a/controller/templates/statefulset.yaml
+++ b/controller/templates/statefulset.yaml
@@ -18,12 +18,9 @@ spec:
       initContainers: []
       volumes:
         {% if oidc["enabled"] %}
-        - name: oauth2-proxy-config
+        - name: config
           configMap:
             name: {{ name }}
-            items:
-              - key: authorized-users.txt
-                path: authorized-users.txt
         {% else %}
         - name: traefik-dynamic-config
           configMap:
@@ -64,6 +61,14 @@ spec:
             sizeLimit: {{ storage["size"] }}
             {% endif %}
         {% endif %}
+        {% if "secretKeyRef" in auth["oidc"]["clientSecret"] %}
+        - name: oidc-client-secret
+          secret:
+            secretName: {{ auth["oidc"]["clientSecret"]["secretKeyRef"]["name"] }}
+        {% endif %}
+        - name: secret
+          secret:
+            secretName: {{ name }}
       terminationGracePeriodSeconds: 30
       automountServiceAccountToken: false
       securityContext:
@@ -148,27 +153,21 @@ spec:
         
         {% if oidc["enabled"] %}
         - name: oauth2-proxy
-          image: "bitnami/oauth2-proxy:7.4.0"
+          image: "bitnami/oauth2-proxy:7.5.1"
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
           args:
-            - "--provider=oidc"
-            - "--client-id={{ oidc["clientId"] }}"
-            - "--oidc-issuer-url={{ oidc["issuerUrl"] }}"
+            - "--alpha-config=/etc/secret/oauth2ProxyConfig.yaml"
             - "--session-cookie-minimal"
             - "--http-address=:4180"
             - "--skip-provider-button"
-            - "--upstream=http://127.0.0.1:8888"
             - "--redirect-url={{ full_url }}/oauth2/callback"
             - "--cookie-path={{ path }}"
             - "--proxy-prefix={{ path if path != '/' else '' }}/oauth2"
-            - "--authenticated-emails-file=/etc/oauth2-proxy/authorized-users.txt"
+            - "--authenticated-emails-file=/etc/config/authorized-users.txt"
             - "--skip-auth-route=^{{ path if path != '/' else '' }}/api/status$"
             - "--exclude-logging-path=/ping"
-            {% for group in oidc["authorizedGroups"] %}
-            - "--allowed-group={{ group }}"
-            {% endfor %}
           ports:
             - name: http
               containerPort: 4180
@@ -179,22 +178,15 @@ spec:
                 secretKeyRef:
                   name: {{ name }}
                   key: oauth2ProxyCookieSecret
-            - name: OAUTH2_PROXY_CLIENT_SECRET
-              valueFrom:
-              {% if "value" in auth["oidc"]["clientSecret"] %}
-                secretKeyRef:
-                  name: {{ name }}
-                  key: oidcClientSecret
-              {% endif %}
-              {% if "secretKeyRef" in auth["oidc"]["clientSecret"] %}
-                secretKeyRef:
-                  name: {{ auth["oidc"]["clientSecret"]["secretKeyRef"]["name"] }}
-                  key: {{ auth["oidc"]["clientSecret"]["secretKeyRef"]["key"] }}
-              {% endif %}
           volumeMounts:
-            - name: oauth2-proxy-config
-              mountPath: /etc/oauth2-proxy/authorized-users.txt
-              subPath: authorized-users.txt
+            - name: config
+              mountPath: /etc/config
+            {% if "secretKeyRef" in auth["oidc"]["clientSecret"] %}
+            - name: oidc-client-secret
+              mountPath: /etc/oauth2-proxy/oidc-client-secret
+            {% endif %}
+            - name: secret
+              mountPath: /etc/secret
           resources:
             requests:
               cpu: 20m


### PR DESCRIPTION
With the latest oauth2 proxy version it can rewrite the path to the upstream application.

This means we can run the jupyter server at `/` rather than at a complicated path.