### PR TITLE
fix(chart): adapt scheduler for new k8s versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-#  (2023-09-06)
+## [0.10.0](https://github.com/SwissDataScienceCenter/amalthea/compare/0.9.1...0.10.0) (2023-10-04)
+
+This release has a breaking change in the values file for the Amalthea Helm chart. This is only relevant
+if you are using the Amalthea scheduler. Please refer to the values file of this release for additional 
+information. All the values from the old version under the `scheduler` key have been removed and replaced
+with new values, so if you wish to retain similar scheduler functionality like before you have to change your
+values file when upgrading.
 
 ## [0.9.1](https://github.com/SwissDataScienceCenter/amalthea/compare/0.9.0...0.9.1) (2023-09-06)
 
@@ -8,8 +14,6 @@
 
 
 
-#  (2023-08-31)
-
 ## [0.9.0](https://github.com/SwissDataScienceCenter/amalthea/compare/0.8.0...0.9.0) (2023-08-31)
 
 ### Features
@@ -17,8 +21,6 @@
 * add two-step culling for sessions ([#366](https://github.com/SwissDataScienceCenter/amalthea/issues/366)) ([bfd88f3](https://github.com/SwissDataScienceCenter/amalthea/commit/bfd88f3a0c3f65dca929cadaafaf14f570443559))
 
 
-
-#  (2023-08-03)
 
 ## [0.8.0](https://github.com/SwissDataScienceCenter/amalthea/compare/0.7.1...0.8.0) (2023-08-03)
 

--- a/helm-chart/amalthea/templates/deployment.yaml
+++ b/helm-chart/amalthea/templates/deployment.yaml
@@ -91,12 +91,12 @@ spec:
             - name: METRICS_EXTRA_LABELS
               value: {{ .Values.metrics.extraMetricsLabels | toJson | quote }}
             {{- include "certificates.env.python" . | nindent 12 }}
-            {{- if .Values.scheduler.packing.enabled }}
-            - name: SERVER_SCHEDULER_NAME
-              value: {{ include "amalthea.fullname" . }}-scheduler
-            {{- else if .Values.scheduler.custom.enabled -}}
+            {{- if .Values.scheduler.custom.enabled }}
             - name: SERVER_SCHEDULER_NAME
               value: {{ .Values.scheduler.custom.name | quote }}
+            {{- else if .Values.scheduler.packing.enabled }}
+            - name: SERVER_SCHEDULER_NAME
+              value: {{ include "amalthea.fullname" . }}-scheduler
             {{- end }}
             - name: AUDITLOG_ENABLED
               value: {{ .Values.auditLog.enabled | quote }}

--- a/helm-chart/amalthea/templates/deployment.yaml
+++ b/helm-chart/amalthea/templates/deployment.yaml
@@ -91,9 +91,12 @@ spec:
             - name: METRICS_EXTRA_LABELS
               value: {{ .Values.metrics.extraMetricsLabels | toJson | quote }}
             {{- include "certificates.env.python" . | nindent 12 }}
-            {{- if .Values.scheduler.enable}}
+            {{- if .Values.scheduler.packing.enabled }}
             - name: SERVER_SCHEDULER_NAME
               value: {{ include "amalthea.fullname" . }}-scheduler
+            {{- else if .Values.scheduler.custom.enabled -}}
+            - name: SERVER_SCHEDULER_NAME
+              value: {{ .Values.scheduler.custom.name | quote }}
             {{- end }}
             - name: AUDITLOG_ENABLED
               value: {{ .Values.auditLog.enabled | quote }}

--- a/helm-chart/amalthea/templates/scheduler/configmap.yaml
+++ b/helm-chart/amalthea/templates/scheduler/configmap.yaml
@@ -15,8 +15,11 @@ data:
     apiVersion: kubescheduler.config.k8s.io/v1beta3
     {{- end }}
     kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: false
     profiles:
-      - pluginConfig:
+      - schedulerName: {{ include "amalthea.fullname" . }}-scheduler
+        pluginConfig:
           - args:
               scoringStrategy:
                 resources:

--- a/helm-chart/amalthea/templates/scheduler/configmap.yaml
+++ b/helm-chart/amalthea/templates/scheduler/configmap.yaml
@@ -1,4 +1,32 @@
-{{- if .Values.scheduler.enable }}
+{{- if .Values.scheduler.packing.enabled }}
+{{- if semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.GitVersion }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "amalthea.fullname" . }}-scheduler-config
+  namespace: {{ .Release.Namespace }}
+data:
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/resource-bin-packing/#enabling-bin-packing-using-mostallocated-strategy
+  config.yaml: |
+    {{- if semverCompare ">=1.25.0-0" .Capabilities.KubeVersion.GitVersion }}
+    apiVersion: kubescheduler.config.k8s.io/v1
+    {{- else }}
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
+    {{- end }}
+    kind: KubeSchedulerConfiguration
+    profiles:
+      - pluginConfig:
+          - args:
+              scoringStrategy:
+                resources:
+                  - name: cpu
+                    weight: 100
+                  - name: memory
+                    weight: 100
+                type: MostAllocated
+            name: NodeResourcesFit
+{{- else }}
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -9,10 +37,29 @@ data:
   policy.cfg: |
     apiVersion: v1
     kind: Policy
-    {{- with .Values.scheduler.priorities }}
     priorities:
-      {{- toYaml . | nindent 6}}
-    {{- end}}
+      - name: MostRequestedPriority
+        weight: 100
+      - name: ServiceSpreadingPriority
+        weight: 1
+      - name: EqualPriority
+        weight: 1
+      - name: ImageLocalityPriority
+        weight: 1
+      - name: SelectorSpreadPriority
+        weight: 1
+      - name: InterPodAffinityPriority
+        weight: 1
+      - name: LeastRequestedPriority
+        weight: 1
+      - name: BalancedResourceAllocation
+        weight: 1
+      - name: NodePreferAvoidPodsPriority
+        weight: 1
+      - name: NodeAffinityPriority
+        weight: 1
+      - name: TaintTolerationPriority
+        weight: 1
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -28,4 +75,5 @@ data:
       leaderElect: false
     profiles:
       - schedulerName: {{ include "amalthea.fullname" . }}-scheduler
+{{- end }}
 {{- end }}

--- a/helm-chart/amalthea/templates/scheduler/deployment.yaml
+++ b/helm-chart/amalthea/templates/scheduler/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             {{- else }}
             - --bind-address=0.0.0.0
             - --secure-port=10251
+            - -v
+            - "2"
+            - --logging-format
+            - json
             {{- end }}
           image: "{{ .Values.scheduler.packing.image.repository }}:{{ .Values.scheduler.packing.image.tag | default .Capabilities.KubeVersion.GitVersion }}"
           imagePullPolicy: {{ .Values.scheduler.packing.image.pullPolicy }}

--- a/helm-chart/amalthea/templates/scheduler/deployment.yaml
+++ b/helm-chart/amalthea/templates/scheduler/deployment.yaml
@@ -24,25 +24,34 @@ spec:
       containers:
         - command:
             - /usr/local/bin/kube-scheduler
-            - --address=0.0.0.0
             - --config=/etc/user-scheduler/config.yaml
             {{- if semverCompare "<1.23.0-0" .Capabilities.KubeVersion.GitVersion }}
+            - --address=0.0.0.0
             - --policy-configmap={{ include "amalthea.fullname" . }}-scheduler-policy
             - --policy-configmap-namespace={{ .Release.Namespace }}
-            {{- end }}
             - --scheduler-name={{ include "amalthea.fullname" . }}-scheduler
+            {{- else }}
+            - --bind-address=0.0.0.0
+            - --secure-port=10251
+            {{- end }}
           image: "{{ .Values.scheduler.packing.image.repository }}:{{ .Values.scheduler.packing.image.tag | default .Capabilities.KubeVersion.GitVersion }}"
           imagePullPolicy: {{ .Values.scheduler.packing.image.pullPolicy }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: 10251
+              {{- if semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.GitVersion }}
+              scheme: HTTPS
+              {{- end }}
             initialDelaySeconds: 15
           name: {{ include "amalthea.fullname" . }}-scheduler
           readinessProbe:
             httpGet:
               path: /healthz
               port: 10251
+              {{- if semverCompare ">=1.23.0-0" .Capabilities.KubeVersion.GitVersion }}
+              scheme: HTTPS
+              {{- end }}
           resources:
             requests:
               cpu: "0.1"

--- a/helm-chart/amalthea/templates/scheduler/deployment.yaml
+++ b/helm-chart/amalthea/templates/scheduler/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - --policy-configmap-namespace={{ .Release.Namespace }}
             {{- end }}
             - --scheduler-name={{ include "amalthea.fullname" . }}-scheduler
-          image: "{{ .Values.scheduler.packing.image.repository }}:{{ .Values.scheduler.packing.image.tag | default .Capabilities.KubeVersion }}"
+          image: "{{ .Values.scheduler.packing.image.repository }}:{{ .Values.scheduler.packing.image.tag | default .Capabilities.KubeVersion.GitVersion }}"
           imagePullPolicy: {{ .Values.scheduler.packing.image.pullPolicy }}
           livenessProbe:
             httpGet:

--- a/helm-chart/amalthea/templates/scheduler/deployment.yaml
+++ b/helm-chart/amalthea/templates/scheduler/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scheduler.enable }}
+{{- if .Values.scheduler.packing.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -26,10 +26,13 @@ spec:
             - /usr/local/bin/kube-scheduler
             - --address=0.0.0.0
             - --config=/etc/user-scheduler/config.yaml
+            {{- if semverCompare "<1.23.0-0" .Capabilities.KubeVersion.GitVersion }}
             - --policy-configmap={{ include "amalthea.fullname" . }}-scheduler-policy
             - --policy-configmap-namespace={{ .Release.Namespace }}
+            {{- end }}
             - --scheduler-name={{ include "amalthea.fullname" . }}-scheduler
-          image: "{{ .Values.scheduler.image.repository }}:{{ .Values.scheduler.image.tag }}"
+          image: "{{ .Values.scheduler.packing.image.repository }}:{{ .Values.scheduler.packing.image.tag | default .Capabilities.KubeVersion }}"
+          imagePullPolicy: {{ .Values.scheduler.packing.image.pullPolicy }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/helm-chart/amalthea/templates/scheduler/rbac.yaml
+++ b/helm-chart/amalthea/templates/scheduler/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scheduler.enable }}
+{{- if .Values.scheduler.packing.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm-chart/amalthea/values.schema.json
+++ b/helm-chart/amalthea/values.schema.json
@@ -391,64 +391,6 @@
             ],
             "additionalProperties": false
         },
-        "scheduler": {
-            "type": "object",
-            "required": [
-                "enable",
-                "image",
-                "priorities"
-            ],
-            "properties": {
-                "enable": {
-                    "type": "boolean"
-                },
-                "image": {
-                    "type": "object",
-                    "required": [
-                        "repository",
-                        "pullPolicy",
-                        "tag"
-                    ],
-                    "properties": {
-                        "repository": {
-                            "type": "string"
-                        },
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "priorities": {
-                    "type": "array",
-                    "additionalItems": true,
-                    "items": {
-                        "anyOf": [
-                            {
-                                "type": "object",
-                                "required": [
-                                    "name",
-                                    "weight"
-                                ],
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "weight": {
-                                        "type": "integer"
-                                    }
-                                },
-                                "additionalProperties": false
-                            }
-                        ]
-                    }
-                }
-            },
-            "additionalProperties": false
-        },
         "resourceUsageCheck": {
             "type": "object",
             "properties": {

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -151,38 +151,22 @@ resourceUsageCheck:
 
 # Deploy an optional additional scheduler in the same namespace where the operator is deployed.
 # The additional scheduler allows for fine grained scheduling policies for the pods managed by this operator.
-# As an example the pods can be scheduled to prioritize the most requested nodes, thus "packing" the workload in
-# as few nodes as possible, instead of spreading them over all the available nodes.
-# NOTE: ensure that the tag of the scheduler image matches the version of the Kubernetes cluster where it is deployed.
 scheduler:
-  enable: false
-  image:
-    repository: k8s.gcr.io/kube-scheduler
-    pullPolicy: IfNotPresent
-    tag: you-MUST-set-a-tag-matching-the-k8s-version-in-your-cluster
-  priorities:
-    - name: MostRequestedPriority
-      weight: 100
-    - name: ServiceSpreadingPriority
-      weight: 1
-    - name: EqualPriority
-      weight: 1
-    - name: ImageLocalityPriority
-      weight: 1
-    - name: SelectorSpreadPriority
-      weight: 1
-    - name: InterPodAffinityPriority
-      weight: 1
-    - name: LeastRequestedPriority
-      weight: 1
-    - name: BalancedResourceAllocation
-      weight: 1
-    - name: NodePreferAvoidPodsPriority
-      weight: 1
-    - name: NodeAffinityPriority
-      weight: 1
-    - name: TaintTolerationPriority
-      weight: 1
+  packing:    
+    # The configuration that is very useful for efficient scheduling and that we provide will pack the workloads in
+    # as few nodes as possible, instead of spreading them over all the available nodes.
+    enabled: false
+    image:
+      repository: k8s.gcr.io/kube-scheduler
+      pullPolicy: IfNotPresent
+      # If you leave the tag empty we will set it based on the Kubernetes cluster version in Helm.
+      # If our guess and/or Helm is not reporting the right Kubernetes version then set the value here.
+      tag: 
+  custom:
+    # If you do not wish to use our bin packing scheduler then deploy your own in the same namespace
+    # as the operator and provide the scheduler name here. Amalthea will use this scheduler to schedule every session.
+    enabled: false
+    name: 
 
 metrics:
   enabled: false

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -152,7 +152,7 @@ resourceUsageCheck:
 # Deploy an optional additional scheduler in the same namespace where the operator is deployed.
 # The additional scheduler allows for fine grained scheduling policies for the pods managed by this operator.
 scheduler:
-  packing:    
+  packing:
     # The configuration that is very useful for efficient scheduling and that we provide will pack the workloads in
     # as few nodes as possible, instead of spreading them over all the available nodes.
     enabled: false
@@ -161,12 +161,13 @@ scheduler:
       pullPolicy: IfNotPresent
       # If you leave the tag empty we will set it based on the Kubernetes cluster version in Helm.
       # If our guess and/or Helm is not reporting the right Kubernetes version then set the value here.
-      tag: 
+      tag:
   custom:
     # If you do not wish to use our bin packing scheduler then deploy your own in the same namespace
     # as the operator and provide the scheduler name here. Amalthea will use this scheduler to schedule every session.
+    # If the custom scheduler is enabled it will take precedence over the packing scheduler.
     enabled: false
-    name: 
+    name:
 
 metrics:
   enabled: false


### PR DESCRIPTION
closes #369 

Also it simplifies the  helm chart values. This way if you want our default packing scheduler you flip on the enabled flag. 

If you need more control you have to deploy your own and pass the scheduler name.