### PR TITLE
fix: status can only be hibernated when server is hibernated

### DIFF
--- a/controller/server_status.py
+++ b/controller/server_status.py
@@ -292,6 +292,8 @@ class ServerStatus:
     @property
     def overall_status(self) -> ServerStatusEnum:
         """Get the status of the jupyterserver."""
+        if self.hibernated:
+            return ServerStatusEnum.Hibernated
         if self.deletion_timestamp:
             return ServerStatusEnum.Stopping
         if self.is_unschedulable:

--- a/controller/server_status.py
+++ b/controller/server_status.py
@@ -305,8 +305,6 @@ class ServerStatus:
                 num_failed_statuses += 1
             elif status.running_ready or status.completed_successfully:
                 num_ok_statuses += 1
-        if self.hibernated:
-            return ServerStatusEnum.Hibernated
         if (
             self.pod_phase == K8sPodPhaseEnum.running
             and num_ok_statuses == len(self.init_statuses) + len(self.statuses)


### PR DESCRIPTION
This is a small fix for a rare bug that Flora noticed.

Basically what could happen is that when you hibernate a session that is failed sometime the function that was modified below would flip the status back to "Failed" but the status should stay "Hibernated".

This fixes the problem.