### PR TITLE
fix: parse unknown or new k8s pod conditions

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -14,7 +14,7 @@ jobs:
   acceptance-tests-images:
     strategy:
       matrix:
-        kind-image-version: ["v1.21.2", "v1.20.7", "v1.19.11"]
+        kind-image-version: ["v1.29.2", "v1.28.7", "v1.27.11", "v1.19.11"]
         helm-version: ["v3.6.3", "v3.0.0"]
         test-image:
           - image: jupyter/minimal-notebook

--- a/controller/server_status.py
+++ b/controller/server_status.py
@@ -158,7 +158,7 @@ class PodConditionsEnum(Enum):
     containers_ready: str = "ContainersReady"  # All containers in the pod are ready
     ready: str = "Ready"  # Pod is able to serve requests and should reachable by services
     ready_to_start: str = "PodReadyToStartContainers"  # Pod sandbox successfully created
-    unknown: str = "Unknown"
+    unknown: str = "Unknown"  # Not part of the known Pod conditions
 
     @classmethod
     def from_string(cls, val: str):
@@ -169,7 +169,7 @@ class PodConditionsEnum(Enum):
         try:
             return cls(val)
         except ValueError:
-            return cls("Unknown")
+            return cls.unknown
 
 
 @dataclass

--- a/controller/server_status.py
+++ b/controller/server_status.py
@@ -161,15 +161,11 @@ class PodConditionsEnum(Enum):
     unknown: str = "Unknown"  # Not part of the known Pod conditions
 
     @classmethod
-    def from_string(cls, val: str):
-        """Generate a pod condition from a string.
-
-        If the condition is not known, return the unknown enum.
+    def _missing_(cls, value):
         """
-        try:
-            return cls(val)
-        except ValueError:
-            return cls.unknown
+        In case the condition is not known, use the unknown enum.
+        """
+        return cls.unknown
 
 
 @dataclass

--- a/controller/server_status.py
+++ b/controller/server_status.py
@@ -157,6 +157,19 @@ class PodConditionsEnum(Enum):
     has_network: str = "PodHasNetwork"  # Pod networking successfully configured
     containers_ready: str = "ContainersReady"  # All containers in the pod are ready
     ready: str = "Ready"  # Pod is able to serve requests and should reachable by services
+    ready_to_start: str = "PodReadyToStartContainers"  # Pod sandbox successfully created
+    unknown: str = "Unknown"
+
+    @classmethod
+    def from_string(cls, val: str):
+        """Generate a pod condition from a string.
+
+        If the condition is not known, return the unknown enum.
+        """
+        try:
+            return cls(val)
+        except ValueError:
+            return cls("Unknown")
 
 
 @dataclass
@@ -170,7 +183,7 @@ class PodCondition:
     @classmethod
     def from_dict(cls, condition_dict: Dict[str, str]):
         return cls(
-            type=PodConditionsEnum(condition_dict["type"]),
+            type=PodConditionsEnum.from_string(condition_dict["type"]),
             last_transition_time=datetime.fromisoformat(
                 condition_dict["lastTransitionTime"].rstrip("Z")
             ),

--- a/controller/server_status.py
+++ b/controller/server_status.py
@@ -179,7 +179,7 @@ class PodCondition:
     @classmethod
     def from_dict(cls, condition_dict: Dict[str, str]):
         return cls(
-            type=PodConditionsEnum.from_string(condition_dict["type"]),
+            type=PodConditionsEnum(condition_dict["type"]),
             last_transition_time=datetime.fromisoformat(
                 condition_dict["lastTransitionTime"].rstrip("Z")
             ),


### PR DESCRIPTION
Newer versions of k8s have different pod statuses and this is causing a problem.


```
{"message": "Handler 'update_server_state' failed with an exception. Will ignore.", "exc_info": "
Traceback (most recent call last):\n  
File \"/usr/local/lib/python3.9/site-packages/kopf/_core/actions/execution.py\", line 276, in execute_handler_once\n
result = await invoke_handler(\n  
File \"/usr/local/lib/python3.9/site-packages/kopf/_core/actions/execution.py\", line 371, in invoke_handler\n    
result = await invocation.invoke(\n  
File \"/usr/local/lib/python3.9/site-packages/kopf/_core/actions/invocation.py\", line 139, in invoke\n    
await asyncio.shield(future)  # slightly expensive: creates tasks\n  
File \"/usr/local/lib/python3.9/concurrent/futures/thread.py\", line 58, in run\n   
result = self.fn(*self.args, **self.kwargs)\n  
File \"/app/controller/server_controller.py\", line 199, in update_server_state\n
server_status = ServerStatus.from_server_spec(\n  
File \"/app/controller/server_status.py\", line 218, in from_server_spec\n    
pod_conditions = [\n  File \"/app/controller/server_status.py\", line 219, in <listcomp>\n    
PodCondition.from_dict(condition) for condition in pod_conditions\n  
File \"/app/controller/server_status.py\", line 173, in from_dict\n    
type=PodConditionsEnum(condition_dict[\"type\"]),\n  
File \"/usr/local/lib/python3.9/enum.py\", line 384, in __call__\n
return cls.__new__(cls, value)\n  
File \"/usr/local/lib/python3.9/enum.py\", line 702, in __new__\n    
raise ve_exc\nValueError: 'PodReadyToStartContainers' is not a valid PodConditionsEnum", 
"timestamp": "2024-04-05T08:09:13.843060+00:00", "object": {"apiVersion": "amalthea.dev/v1alpha1", "kind": "JupyterServer", "name": "samuel-2eg-test-2drenku-b7a7411c", "uid": "ce3970f0-d782-46fb-8171-12bf7c797567", "namespace": "renku"}, "severity │
│ ": "error"}
```