### PR TITLE
chore: Remove default resources requests and limits.

### DIFF
--- a/helm-chart/amalthea/values.schema.json
+++ b/helm-chart/amalthea/values.schema.json
@@ -220,10 +220,7 @@
                             ]
                         }
                     },
-                    "required": [
-                        "memory",
-                        "cpu"
-                    ],
+                    "required": [],
                     "additionalProperties": false
                 },
                 "requests": {
@@ -242,18 +239,12 @@
                             ]
                         }
                     },
-                    "required": [
-                        "memory",
-                        "cpu"
-                    ],
+                    "required": [],
                     "additionalProperties": false
                 }
             },
             "additionalProperties": false,
-            "required": [
-                "limits",
-                "requests"
-            ]
+            "required": []
         },
         "nodeSelector": {
             "type": "object"

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -106,13 +106,13 @@ securityContext:
   runAsNonRoot: true
   allowPrivilegeEscalation: false
 
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+resources: {}
+#   limits:
+#     cpu: 100m
+#     memory: 128Mi
+#   requests:
+#     cpu: 100m
+#     memory: 128Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
They might interfere with what is set downstream, e.g.
if the admins do not want to set a limit for CPU (which
is a best practice).
