### PR TITLE
fix: Change the default registry to pull kube-scheduler from.

### DIFF
--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -157,7 +157,7 @@ scheduler:
     # as few nodes as possible, instead of spreading them over all the available nodes.
     enabled: false
     image:
-      repository: k8s.gcr.io/kube-scheduler
+      repository: registry.k8s.io/kube-scheduler
       pullPolicy: IfNotPresent
       # If you leave the tag empty we will set it based on the Kubernetes cluster version in Helm.
       # If our guess and/or Helm is not reporting the right Kubernetes version then set the value here.


### PR DESCRIPTION
As the former is no longer available.
