### PR TITLE
feat(crd): AmaltheaSession definition

### DIFF
--- a/controller/crds/amaltheasession.yaml
+++ b/controller/crds/amaltheasession.yaml
@@ -27,7 +27,7 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          description: AlmaltheaSession is the Schema for the session API
+          description: AmaltheaSession is the Schema for the session API
           properties:
             spec:
               type: object
@@ -103,7 +103,7 @@ spec:
                 extraContainers:
                   type: array
                   default: []
-                  description: Sidecar containers to run along the main cotnainer
+                  description: Extra containers to run alongside the main container
                   items:
                     type: object
                     properties:
@@ -147,7 +147,7 @@ spec:
                 initContainers:
                   type: array
                   default: []
-                  description: Sidecar containers to run along the main cotnainer
+                  description: Init containers that run before the rest
                   items:
                     type: object
                     properties:
@@ -221,39 +221,40 @@ spec:
                       minimum: 0
                       description:
                         The maximum allowed age for a session, regardless of whether it
-                        is active or not. A value of zero indicates that the server cannot be
-                        culled due to its age.
+                        is active or not. When the threshold is reached the session is hibernated.
+                        A value of zero indicates that Amalthea will not automatically hibernate
+                        the session based on its age.
                     idleSecondsThreshold:
                       type: integer
                       minimum: 0
                       default: 0
                       description:
-                        How long should a server be idle for before it is culled. A value of
-                        zero indicates that the server should never be culled for inactivity.
+                        How long should a server be idle for before it is hibernated. A value of
+                        zero indicates that Amalthea will not automatically hibernate inactive sessions.
                     startingSecondsThreshold:
                       type: integer
                       default: 0
                       minimum: 0
                       description:
-                        How long can a server be in starting state before it gets culled. A
-                        value of zero indicates that the server cannot be culled due to
-                        starting too long.
+                        How long can a server be in starting state before it gets hibernated. A
+                        value of zero indicates that the server will not be automatically hibernated
+                        by Amalthea because it took to long to start.
                     failedSecondsThreshold:
                       type: integer
                       default: 0
                       minimum: 0
                       description:
-                        How long can a server be in failed state before it gets culled. A
-                        value of zero indicates that the server cannot be culled due to
-                        failing.
+                        How long can a server be in failed state before it gets hibernated. A
+                        value of zero indicates that the server will not be automatically
+                        hibernated by Amalthea if it is failing.
                     hibernatedSecondsThreshold:
                       type: integer
                       default: 0
                       minimum: 0
                       description:
                         Number of seconds where a server can be in hibernated state before
-                        it gets culled. A value of zero indicates that hibernated servers
-                        cannot be culled.
+                        it gets completely deleted. A value of zero indicates that hibernated servers
+                        will not be automatically be deleted by Amalthea after a period of time.
                 oidc:
                   type: object
                   default: {}

--- a/controller/crds/amaltheasession.yaml
+++ b/controller/crds/amaltheasession.yaml
@@ -85,10 +85,18 @@ spec:
                         - value
                     image:
                       type: string
-                    memoryLimit:
-                      type: string
-                    cpuLimit:
-                      type: string
+                    resources:
+                      type: object
+                      default: {}
+                      description: >-
+                        Pod resources request
+                        example:
+                          requests:
+                            memory: "64Mi"
+                            cpu: "250m"
+                          limits:
+                            memory: "128Mi"
+                            cpu: "500m"
                     name:
                       type: string
                   required:
@@ -128,10 +136,18 @@ spec:
                           - value
                       image:
                         type: string
-                      memoryLimit:
-                        type: string
-                      cpuLimit:
-                        type: string
+                      resources:
+                        type: object
+                        default: {}
+                        description: >-
+                          Pod resources request
+                          example:
+                            requests:
+                              memory: "64Mi"
+                              cpu: "250m"
+                            limits:
+                              memory: "128Mi"
+                              cpu: "500m"
                       name:
                         type: string
                     required:
@@ -172,12 +188,18 @@ spec:
                           - value
                       image:
                         type: string
-                      memoryLimit:
-                        type: string
-                      cpuLimit:
-                        type: string
-                      name:
-                        type: string
+                      resources:
+                        type: object
+                        default: {}
+                        description: >-
+                          Pod resources request
+                          example:
+                            requests:
+                              memory: "64Mi"
+                              cpu: "250m"
+                            limits:
+                              memory: "128Mi"
+                              cpu: "500m"
                     required:
                     - name
                     - image

--- a/controller/crds/amaltheasession.yaml
+++ b/controller/crds/amaltheasession.yaml
@@ -249,7 +249,7 @@ spec:
                         Number of seconds where a server can be in hibernated state before
                         it gets completely deleted. A value of zero indicates that hibernated servers
                         will not be automatically be deleted by Amalthea after a period of time.
-                oidc:
+                authentication:
                   type: object
                   default: {}
                   description: OIDC configuration
@@ -260,8 +260,21 @@ spec:
                       description: Whether OIDC is enabled for this environement
                     configuration:
                       type: object
-                      description: Configuration to be applied
+                      description: Authentication configuration options
+                      oneOf:
+                        - required:
+                            - token
+                        - required:
+                            - oidc
                       properties:
-                        secretRef:
+                        token:
                           type: string
-                          description: Name of the secret containing the OIDC configuration
+                          description: A pre-generated token that can be used to authenticate a
+                            user.
+                        configuration:
+                          type: object
+                          description: Configuration to be applied
+                          properties:
+                            secretRef:
+                              type: string
+                              description: Name of the secret containing the OIDC configuration

--- a/controller/crds/amaltheasession.yaml
+++ b/controller/crds/amaltheasession.yaml
@@ -1,0 +1,272 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: amaltheasessions.amalthea.dev
+spec:
+  scope: Namespaced
+  group: amalthea.dev
+  names:
+    plural: amaltheasessions
+    singular: amaltheasession
+    kind: AlmaltheaSession
+    shortNames:
+    - asn
+
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - jsonPath: .status.phase
+          description: The current session startup phase
+          name: Phase
+          type: string
+      subresources:
+          status: {}
+
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: AlmaltheaSession is the Schema for the session API
+          properties:
+            spec:
+              type: object
+              description: User defined specification for an Amalthea Session custom resource.
+              properties:
+                projects:
+                  type: array
+                  description: Projects to bring into the session
+                  items:
+                    type: object
+                    properties:
+                      clonePath:
+                        type: string
+                        description: Path relative to the root of the projects to where
+                          the project should be cloned into.
+                      git:
+                        type: object
+                        description: Project's git source
+                        properties:
+                          checkoutFrom:
+                            type: object
+                            description: Defines from what the project should be checked
+                              out from.
+                            properties:
+                              remote:
+                                type: string
+                                description: The remote name.
+                              revision:
+                                type: string
+                                description: The revision to be checkout from. This can
+                                  be a branch, tag or commit id.
+
+                container:
+                  type: object
+                  description: session container specification
+                  properties:
+                    args:
+                      type: array
+                      description: Arguments passed to the command of the image or the
+                        overridden command below.
+                      items:
+                        type: string
+                    command:
+                      type: array
+                      description: Command to run in place of the image provided
+                        command.
+                      items:
+                        type: string
+                    env:
+                      type: array
+                      description: Environment variables used in this container
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                    image:
+                      type: string
+                    memoryLimit:
+                      type: string
+                    cpuLimit:
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - name
+
+                extraContainers:
+                  type: array
+                  default: []
+                  description: Sidecar containers to run along the main cotnainer
+                  items:
+                    type: object
+                    properties:
+                      args:
+                        type: array
+                        description: Arguments passed to the command of the image or the
+                          overridden command below.
+                        items:
+                          type: string
+                      command:
+                        type: array
+                        description: Command to run in place of the image provided
+                          command.
+                        items:
+                          type: string
+                      env:
+                        type: array
+                        description: Environment variables used in this container
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                      image:
+                        type: string
+                      memoryLimit:
+                        type: string
+                      cpuLimit:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - name
+                    - image
+
+                initContainers:
+                  type: array
+                  default: []
+                  description: Sidecar containers to run along the main cotnainer
+                  items:
+                    type: object
+                    properties:
+                      args:
+                        type: array
+                        description: Arguments passed to the command of the image or the
+                          overridden command below.
+                        items:
+                          type: string
+                      command:
+                        type: array
+                        description: Command to run in place of the image provided
+                          command.
+                        items:
+                          type: string
+                      env:
+                        type: array
+                        description: Environment variables used in this container
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                      image:
+                        type: string
+                      memoryLimit:
+                        type: string
+                      cpuLimit:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - name
+                    - image
+
+                dataSources:
+                  type: array
+                  default: []
+                  description: List of data source to connect to and mount in the main
+                    container.
+                  items:
+                    type: object
+                    properties:
+                      remote:
+                        type: string
+                        description: URL of the data source to connect to
+                      mountPath:
+                        type: string
+                        description: Path to were the data source should be mounted
+                      secret:
+                        type: string
+                        description: Name of the secret containing the credentials for the
+                          data source.
+                    required:
+                      - remote
+                      - mountPath
+
+                culling:
+                  type: object
+                  default: {}
+                  description: Options about culling idle servers
+                  properties:
+                    maxAgeSecondsThreshold:
+                      type: integer
+                      default: 0
+                      minimum: 0
+                      description:
+                        The maximum allowed age for a session, regardless of whether it
+                        is active or not. A value of zero indicates that the server cannot be
+                        culled due to its age.
+                    idleSecondsThreshold:
+                      type: integer
+                      minimum: 0
+                      default: 0
+                      description:
+                        How long should a server be idle for before it is culled. A value of
+                        zero indicates that the server should never be culled for inactivity.
+                    startingSecondsThreshold:
+                      type: integer
+                      default: 0
+                      minimum: 0
+                      description:
+                        How long can a server be in starting state before it gets culled. A
+                        value of zero indicates that the server cannot be culled due to
+                        starting too long.
+                    failedSecondsThreshold:
+                      type: integer
+                      default: 0
+                      minimum: 0
+                      description:
+                        How long can a server be in failed state before it gets culled. A
+                        value of zero indicates that the server cannot be culled due to
+                        failing.
+                    hibernatedSecondsThreshold:
+                      type: integer
+                      default: 0
+                      minimum: 0
+                      description:
+                        Number of seconds where a server can be in hibernated state before
+                        it gets culled. A value of zero indicates that hibernated servers
+                        cannot be culled.
+                oidc:
+                  type: object
+                  default: {}
+                  description: OIDC configuration
+                  properties:
+                    enabled:
+                      type: boolean
+                      default: false
+                      description: Whether OIDC is enabled for this environement
+                    configuration:
+                      type: object
+                      description: Configuration to be applied
+                      properties:
+                        secretRef:
+                          type: string
+                          description: Name of the secret containing the OIDC configuration

--- a/controller/crds/amaltheasession.yaml
+++ b/controller/crds/amaltheasession.yaml
@@ -33,33 +33,27 @@ spec:
               type: object
               description: User defined specification for an Amalthea Session custom resource.
               properties:
-                projects:
+                codeRepositories:
                   type: array
-                  description: Projects to bring into the session
+                  description: Code that will be pulled into the session
                   items:
                     type: object
                     properties:
                       clonePath:
                         type: string
-                        description: Path relative to the root of the projects to where
-                          the project should be cloned into.
+                        description: Path relative to the root of the work folder to where
+                          the repository should be cloned into.
                       git:
                         type: object
                         description: Project's git source
                         properties:
-                          checkoutFrom:
-                            type: object
-                            description: Defines from what the project should be checked
-                              out from.
-                            properties:
-                              remote:
-                                type: string
-                                description: The remote name.
-                              revision:
-                                type: string
-                                description: The revision to be checkout from. This can
-                                  be a branch, tag or commit id.
-
+                          remote:
+                            type: string
+                            description: The remote name.
+                          revision:
+                            type: string
+                            description: The revision to be checkout from. This can
+                              be a branch, tag or commit id.
                 container:
                   type: object
                   description: session container specification


### PR DESCRIPTION
## Describe your changes

This PR implements the new AmaltheaSession CRD.

The goal of the this new session is to give user the option to use other development environments than just JupyterLab.

New Docker images as well as instructions will be created as well as part of the implementation.

## Issue ticket number and link

Part of https://github.com/SwissDataScienceCenter/renku/issues/3679
