### PR TITLE
feat(addEnvFrom): possibility to inject env variables

### DIFF
--- a/helm-chart/amalthea/templates/deployment.yaml
+++ b/helm-chart/amalthea/templates/deployment.yaml
@@ -56,6 +56,17 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.envFromConfigMaps }}
+          envFrom:
+            {{- range .Values.envFromConfigMaps }}
+            - configMapRef:
+                name: {{ .name }}
+                optional: {{ .optional | default false }}
+              {{- if .prefix }}
+              prefix: {{ .prefix }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
           env:
             - name: CRD_API_GROUP
               value: {{ .Values.crdApiGroup }}

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -14,7 +14,8 @@ global:
       tag: "0.0.2"
     customCAs: []
       # - secret:
-
+# Inject some extra env variables directly from a config map
+envFromConfigMaps: []
 # Indicate the scope which this operator watches for
 # JupyterServer resources.
 scope:
@@ -37,7 +38,7 @@ scope:
 deployCrd: true # whether to deploy the jupyterserver CRD
 
 networkPolicies:
-  # # Enable sensible, default network policies. Note that until cluster-wide 
+  # # Enable sensible, default network policies. Note that until cluster-wide
   # # network policies are available in Kubernetes (https://github.com/kubernetes/enhancements/issues/2091),
   # # enabling network policies for the servers won't do anything if the scope of the
   # # operator is set to clusterWide. These default policies disable all ingress


### PR DESCRIPTION
# What 

Allows users to create a configmap and directly inject env variables into the pods

# Why 

You may need to inject some custom defines variables such as but not limited to proxy configuration , for exemple. 