### PR TITLE
feat(networkpolicies): customize cluster IPs

### DIFF
--- a/helm-chart/amalthea/templates/networkpolicies.yaml
+++ b/helm-chart/amalthea/templates/networkpolicies.yaml
@@ -64,9 +64,7 @@ spec:
       - ipBlock:
           cidr: 0.0.0.0/0
           except:
-          - 10.0.0.0/8
-          - 172.16.0.0/12
-          - 192.168.0.0/16
+{{ toYaml $.Values.networkPolicies.clusterIpBlock | indent 10 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-chart/amalthea/values.schema.json
+++ b/helm-chart/amalthea/values.schema.json
@@ -71,12 +71,16 @@
             "type": "boolean"
         },
         "networkPolicies": {
-            "description": "Enable default network policies for the controller and jupyter servers.",
+            "description": "Enable and configure network policies for the controller and jupyter servers.",
             "type": "object",
             "properties": {
                 "enabled": {
                     "type": "boolean",
                     "default": true
+                },
+                "clusterIpBlock": {
+                    "type": "array",
+                    "default": ["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
                 }
             },
             "additionalProperties": false,

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -49,6 +49,12 @@ networkPolicies:
   # #             are blocked
   # #   - ingress: allowed only on port 4180 for TCP so that the oauth2proxy can be reached
   enabled: true
+  # # Do not allow deployment to communicate with private cluster IPs.
+  clusterIpBlock:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
+
 
 kopf:
   # # Configure the kopf operator settings by providing


### PR DESCRIPTION
# What

Allows a user to customize his network according to internal needs

# Why 
 
In case a user have another network with private Ips that needs to be reached, this allow the user to deploy a more custom networkpolicy for more flexibility