### PR TITLE
feat: implement secret adoption

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -237,3 +237,19 @@ func (cr *AmaltheaSession) Pod(ctx context.Context, clnt client.Client) (*v1.Pod
 	err := clnt.Get(ctx, key, &pod)
 	return &pod, err
 }
+
+// Returns the list of all the secrets used in this CR
+func (cr *AmaltheaSession) AllSecrets() v1.SecretList {
+	secrets := v1.SecretList{}
+
+	if cr.Spec.Ingress != nil && cr.Spec.Ingress.TLSSecretName != nil {
+		secrets.Items = append(secrets.Items, v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cr.Namespace,
+				Name:      *cr.Spec.Ingress.TLSSecretName,
+			},
+		})
+	}
+
+	return secrets
+}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -30,3 +30,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - delete
+  - get
+  - list

--- a/internal/controller/amaltheasession_controller.go
+++ b/internal/controller/amaltheasession_controller.go
@@ -55,6 +55,7 @@ const secretCleanupFinalizerName = "amalthea.dev/secrets-finalizer"
 //+kubebuilder:rbac:groups=amalthea.dev,resources=amaltheasessions,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=amalthea.dev,resources=amaltheasessions/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=amalthea.dev,resources=amaltheasessions/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/amaltheasession_controller_test.go
+++ b/internal/controller/amaltheasession_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	amaltheadevv1alpha1 "github.com/SwissDataScienceCenter/amalthea/api/v1alpha1"
@@ -74,6 +75,7 @@ var _ = Describe("AmaltheaSession Controller", func() {
 			By("Cleanup the specific resource instance AmaltheaSession")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
+
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &AmaltheaSessionReconciler{
@@ -130,6 +132,7 @@ var _ = Describe("AmaltheaSession Controller", func() {
 			By("Cleanup the specific resource instance AmaltheaSession")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
+
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &AmaltheaSessionReconciler{
@@ -144,5 +147,89 @@ var _ = Describe("AmaltheaSession Controller", func() {
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})
+	})
+
+	Context("Adopting secrets", func() {
+		const resourceName = "test-resource"
+		const secretName = "test-secret"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		amaltheasession := &amaltheadevv1alpha1.AmaltheaSession{}
+
+		secretNamespacedName := types.NamespacedName{
+			Name:      secretName,
+			Namespace: "default", // TODO(user):Modify as needed
+		}
+		secret := &corev1.Secret{}
+
+		BeforeEach(func() {
+			tlsSecretName := secretName
+
+			amaltheasession = &amaltheadevv1alpha1.AmaltheaSession{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: amaltheadevv1alpha1.AmaltheaSessionSpec{
+					Session: amaltheadevv1alpha1.Session{
+						Image: "debian:bookworm-slim",
+						Port:  8000,
+					},
+					Ingress: &amaltheadevv1alpha1.Ingress{
+						Host:          "test.com",
+						TLSSecretName: &tlsSecretName,
+					},
+					AdoptSecrets: false,
+				},
+			}
+
+			err := k8sClient.Get(ctx, secretNamespacedName, secret)
+			if err != nil && errors.IsNotFound(err) {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretName,
+						Namespace: "default",
+					},
+				}
+				Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
+		})
+
+		DescribeTable("Manage secrets",
+			func(adoptSecrets bool) {
+				By("Ensuring the session has the correct configuration")
+				amaltheasession.Spec.AdoptSecrets = adoptSecrets
+				err := k8sClient.Get(ctx, typeNamespacedName, amaltheasession)
+				if err != nil && errors.IsNotFound(err) {
+					Expect(k8sClient.Create(ctx, amaltheasession)).To(Succeed())
+				}
+
+				actual := amaltheadevv1alpha1.AmaltheaSession{}
+				Expect(k8sClient.Get(ctx, typeNamespacedName, &actual)).To(Succeed())
+				Expect(actual.Spec.AdoptSecrets).To(Equal(adoptSecrets))
+
+				By("Deleting the session")
+				Expect(k8sClient.Delete(ctx, &actual)).To(Succeed())
+
+				By("Checking the secret existence matches expectation")
+				err = k8sClient.Get(ctx, secretNamespacedName, secret)
+				if adoptSecrets {
+					Expect(errors.IsNotFound(err))
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+			},
+			Entry("When secrets are adopted", true),
+			Entry("When secrets are not adopted", false),
+		)
 	})
 })


### PR DESCRIPTION
## Describe your changes

This PR implements secrets adoption where secrets used for AmaltheaSession will get deleted when the session itself is deleted.

Following discussion, the method selected is through a finalizer.

## Issue ticket number and link

Closes #632 
Part of https://github.com/SwissDataScienceCenter/renku/issues/3679
