### PR TITLE
fix(crd): use optional in place of omitempty for authentication.enabled

### DIFF
--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -234,8 +234,10 @@ const Token AuthenticationType = "token"
 const Oidc AuthenticationType = "oauth2proxy"
 
 type Authentication struct {
+	// +optional
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=true
-	Enabled bool               `json:"enabled,omitempty"`
+	Enabled bool               `json:"enabled"`
 	Type    AuthenticationType `json:"type"`
 	// Kubernetes secret that contains the authentication configuration
 	// For `token` generate a hard to guess string / password-like string.


### PR DESCRIPTION
## Describe your changes

omitempty triggers a strange behaviour: even if enabled is set to false in the CRD yaml, it will get the default value on initial apply call.

Using the optional markers keeps the CRD definition but without that unexpected behaviour.

## Issue ticket number and link

Related to #614 and #637
Part of https://github.com/SwissDataScienceCenter/renku/issues/3679
