### PR TITLE
chore(ci): fix chart publish step

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.8
-          cache: pipenv
       - name: Publish chart and push images
         env:
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}


### PR DESCRIPTION
This was failing because we do not use pipenv anymore to install things but the setup python action was setup to cache a pipenv virtualenv.

See https://github.com/SwissDataScienceCenter/amalthea/actions/runs/10263017074/job/28394359782 for failing job