### PR TITLE
fix: kopf healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.12.2](https://github.com/SwissDataScienceCenter/amalthea/compare/0.12.1...0.12.2) (2024-08-07)
+
+
+### Bug Fixes
+
+* add kopf liveness check ([3c4daa1](https://github.com/SwissDataScienceCenter/amalthea/commit/3c4daa1420f6faab031d87be95198e8647771a0f))
+
+
+
 ## [0.12.1](https://github.com/SwissDataScienceCenter/amalthea/compare/0.12.0...0.12.1) (2024-08-06)
 
 

--- a/controller/main.py
+++ b/controller/main.py
@@ -187,13 +187,13 @@ async def run(ready_flag: threading.Event | None = None, stop_flag: threading.Ev
     logging.info(f"The changing handlers we start with is {len(registry._changing._handlers)}")
     logging.info(f"The webhooks handlers we start with is {len(registry._webhooks._handlers)}")
 
-    kopf.spawn_tasks
     await kopf.operator(
         registry=registry,
         clusterwide=config.CLUSTER_WIDE,
         namespaces=config.NAMESPACES,
         ready_flag=ready_flag,
         stop_flag=stop_flag,
+        liveness_endpoint="http://0.0.0.0:8080/healthz",
     )
 
 

--- a/helm-chart/amalthea/Chart.yaml
+++ b/helm-chart/amalthea/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.12.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amalthea"
-version = "0.12.1"
+version = "0.12.2"
 description = "A Kubernetes operator for interactive user sessions for Renku"
 authors = ["SDSC <info@datascience.ch>"]
 readme = "README.md"


### PR DESCRIPTION
After changing how some of the internal kopf code is organized I accidentally turned off the health check endpoint.

Now it is back on. 