### PR TITLE
feat(cloner): clone strategies

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -394,7 +394,7 @@ func (cr *AmaltheaSession) initClones() ([]v1.Container, []v1.Volume) {
 	containers := []v1.Container{}
 
 	for irepo, repo := range cr.Spec.CodeRepositories {
-		args := []string{"clone", "--remote", repo.Remote, "--path", cr.Spec.Session.Storage.MountPath + "/" + repo.ClonePath}
+		args := []string{"clone", "--strategy", "notifexist", "--remote", repo.Remote, "--path", cr.Spec.Session.Storage.MountPath + "/" + repo.ClonePath}
 
 		if repo.CloningConfigSecretRef != nil {
 			secretVolName := fmt.Sprintf("git-clone-cred-volume-%d", irepo)

--- a/cloner/cmd/clone.go
+++ b/cloner/cmd/clone.go
@@ -92,6 +92,7 @@ func clone(cmd *cobra.Command, args []string) {
 		log.Fatal("expecting <user>/<repo> in url path, received: ", endpoint.Path)
 	}
 	projectName := splittedRepo[len(splittedRepo)-1]
+	projectName = strings.TrimSuffix(projectName, ".git")
 
 	clonePath := projectName
 	if path != "" {

--- a/cloner/cmd/clone.go
+++ b/cloner/cmd/clone.go
@@ -100,12 +100,14 @@ func clone(cmd *cobra.Command, args []string) {
 	}
 
 	if !strategy.Equal("default") {
+		// check if target exists
 		_, err := os.Stat(clonePath)
 
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Fatal("unexpected error: ", err)
 		}
 
+		// if target folder exists, apply strategy
 		if err == nil {
 			if strategy.Equal("notifexist") {
 				log.Print(clonePath, " already exist, doing nothing")

--- a/cloner/cmd/clone.go
+++ b/cloner/cmd/clone.go
@@ -88,8 +88,8 @@ func clone(cmd *cobra.Command, args []string) {
 	}
 
 	splittedRepo := strings.FieldsFunc(endpoint.Path, func(c rune) bool { return c == '/' }) // FieldsFunc handles repeated and beginning/ending separator characters more sanely than Split
-	if len(splittedRepo) < 2 {
-		log.Fatal("expecting <user>/<repo> in url path, received: ", endpoint.Path)
+	if !(len(splittedRepo) > 0) {
+		log.Fatal("expecting repo in url path, received: ", endpoint.Path)
 	}
 	projectName := splittedRepo[len(splittedRepo)-1]
 	projectName = strings.TrimSuffix(projectName, ".git")

--- a/cloner/cmd/clone.go
+++ b/cloner/cmd/clone.go
@@ -84,7 +84,7 @@ func clone(cmd *cobra.Command, args []string) {
 
 	endpoint, err := transport.NewEndpoint(remote)
 	if err != nil {
-		log.Fatal("failed to parse remote", err)
+		log.Fatal("failed to parse remote: ", err)
 	}
 
 	splittedRepo := strings.FieldsFunc(endpoint.Path, func(c rune) bool { return c == '/' }) // FieldsFunc handles repeated and beginning/ending separator characters more sanely than Split
@@ -103,7 +103,7 @@ func clone(cmd *cobra.Command, args []string) {
 		_, err := os.Stat(clonePath)
 
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			log.Fatal("unexpected error", err)
+			log.Fatal("unexpected error: ", err)
 		}
 
 		if err == nil {
@@ -116,7 +116,7 @@ func clone(cmd *cobra.Command, args []string) {
 				log.Print("deleting clone")
 				err = os.RemoveAll(clonePath + "/")
 				if err != nil {
-					log.Fatal("failed to remove existing clone", err)
+					log.Fatal("failed to remove existing clone: ", err)
 				}
 			}
 		}
@@ -136,13 +136,13 @@ func clone(cmd *cobra.Command, args []string) {
 	if configPath != "" {
 		buf, err := os.ReadFile(configPath)
 		if err != nil {
-			log.Fatal("failed to read configuration file", err)
+			log.Fatal("failed to read configuration file: ", err)
 		}
 
 		cloneFonfig := &CloneFonfig{}
 		err = yaml.Unmarshal(buf, cloneFonfig)
 		if err != nil {
-			log.Fatal("failed to parse configuration:", err)
+			log.Fatal("failed to parse configuration: ", err)
 		}
 
 		if cloneFonfig.PrivateKey == nil && cloneFonfig.Username == nil {
@@ -152,7 +152,7 @@ func clone(cmd *cobra.Command, args []string) {
 		if cloneFonfig.PrivateKey != nil {
 			publicKeys, err := ssh.NewPublicKeys("git", []byte(*cloneFonfig.PrivateKey), cloneFonfig.Password)
 			if err != nil {
-				log.Fatal("generate publickeys failed:", err)
+				log.Fatal("generate publickeys failed: ", err)
 			}
 			cloneOptions.Auth = publicKeys
 		} else if cloneFonfig.Username != nil {
@@ -167,6 +167,6 @@ func clone(cmd *cobra.Command, args []string) {
 	_, err = git.PlainClone(clonePath, false, &cloneOptions)
 
 	if err != nil {
-		log.Fatal("clone failed:", err)
+		log.Fatal("clone failed: ", err)
 	}
 }

--- a/cloner/cmd/enum_flag.go
+++ b/cloner/cmd/enum_flag.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Based on: https://github.com/spf13/pflag/issues/236#issuecomment-931600452
+
+package cmd
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type enum struct {
+	Allowed []string
+	Value   string
+}
+
+// newEnum give a list of allowed flag parameters, where the second argument is the default
+func newEnum(allowed []string, def string) *enum {
+	return &enum{
+		Allowed: allowed,
+		Value:   def,
+	}
+}
+
+func (flag enum) String() string {
+	return flag.Value
+}
+
+func (flag *enum) Set(value string) error {
+	if !slices.Contains(flag.Allowed, value) {
+		return fmt.Errorf("%s is not included in %s", value, strings.Join(flag.Allowed, ","))
+	}
+	flag.Value = value
+	return nil
+}
+
+func (flag *enum) Type() string {
+	return "string"
+}
+
+func (flag *enum) Equal(value string) bool {
+	return flag.Value == value
+}


### PR DESCRIPTION
## Describe your changes

This PR implements strategies about acting before cloning.

There are three strategies:
- default: do as usual and git clone
- notifexists: don't clone if the target folder already exists
- overwrite: delete the target folder before cloning

This happens before trying to clone anything.

The goal is to allow restarting the session which means also the init container and not fail the cloning if it already happened before.

As a drive by cleanup, the `.git` extension is removed if part of the URL as happen when using the git command.

## Issue ticket number and link

Part of: #612
Part of https://github.com/SwissDataScienceCenter/renku/issues/3679
