### PR TITLE
feat: quieter idleness

### DIFF
--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -363,7 +363,7 @@ func (c ChildResourceUpdates) Status(
 			if idle && idleSince.IsZero() {
 				idleSince = metav1.NewTime(time.Now())
 			}
-			if !idle && !idleSince.IsZero() {
+			else if !idle && !idleSince.IsZero() {
 				idleSince = metav1.Time{}
 			}
 		}

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -362,8 +362,7 @@ func (c ChildResourceUpdates) Status(
 			idle = isIdle(ctx, r.MetricsClient, cr)
 			if idle && idleSince.IsZero() {
 				idleSince = metav1.NewTime(time.Now())
-			}
-			else if !idle && !idleSince.IsZero() {
+			} else if !idle && !idleSince.IsZero() {
 				idleSince = metav1.Time{}
 			}
 		}

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -50,6 +50,11 @@ type ChildResourceUpdates struct {
 	DataSourcesPVCs []ChildResourceUpdate[v1.PersistentVolumeClaim]
 }
 
+// The metrics server requires at least 10 seconds before container metrics can
+// be considered accurate, let's wait a little longer before requesting metrics
+// https://github.com/kubernetes-sigs/metrics-server/blob/9ebbad973db2a54193712c4d9292bbe3eaa849dc/pkg/storage/pod.go#L31
+const freshContainerMinimalAge = 15 * time.Second
+
 func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr *amaltheadevv1alpha1.AmaltheaSession) ChildResourceUpdate[T] {
 	log := log.FromContext(ctx)
 	if c.Current == nil {
@@ -334,13 +339,34 @@ func (c ChildResourceUpdates) Status(
 ) amaltheadevv1alpha1.AmaltheaSessionStatus {
 	log := log.FromContext(ctx)
 
-	idle := isIdle(ctx, r.MetricsClient, cr)
-	idleSince := cr.Status.IdleSince
-	if idle && idleSince.IsZero() {
-		idleSince = metav1.NewTime(time.Now())
+	pod, err := cr.Pod(ctx, r.Client)
+	if err != nil && !apierrors.IsNotFound(err) {
+		log.Error(err, "Could not read the session pod when updating the status")
 	}
-	if !idle && !idleSince.IsZero() {
-		idleSince = metav1.Time{}
+
+	idle := false
+	idleSince := cr.Status.IdleSince
+
+	if pod != nil {
+		oldEnough := false
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.Name == amaltheadevv1alpha1.SessionContainerName {
+				if containerStatus.State.Running != nil {
+					oldEnough = time.Since(containerStatus.State.Running.StartedAt.Time) >= freshContainerMinimalAge
+				}
+				break
+			}
+		}
+
+		if c.State(cr, pod) == amaltheadevv1alpha1.Running && oldEnough {
+			idle = isIdle(ctx, r.MetricsClient, cr)
+			if idle && idleSince.IsZero() {
+				idleSince = metav1.NewTime(time.Now())
+			}
+			if !idle && !idleSince.IsZero() {
+				idleSince = metav1.Time{}
+			}
+		}
 	}
 
 	hibernated := cr.Spec.Hibernated
@@ -350,11 +376,6 @@ func (c ChildResourceUpdates) Status(
 	}
 	if !hibernated && !hibernatedSince.IsZero() {
 		hibernatedSince = metav1.Time{}
-	}
-
-	pod, err := cr.Pod(ctx, r.Client)
-	if err != nil && !apierrors.IsNotFound(err) {
-		log.Error(err, "Could not read the session pod when updating the status")
 	}
 
 	failing := pod != nil && podIsFailed(pod)

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -118,13 +118,15 @@ func isIdle(ctx context.Context, clnt metricsv1beta1.PodMetricsesGetter, cr *ama
 
 	cpuUsage := metrics.Cpu()
 	if cpuUsage != nil && cpuUsage.Cmp(cpuUsageIdlenessThreshold) == -1 {
-		log.Info(
-			"the session was found to be idle",
-			"cpu usage milicores",
-			cpuUsage.MilliValue(),
-			"idle threshold milicores",
-			cpuUsageIdlenessThreshold.MilliValue(),
-		)
+		if cr.Status.IdleSince.IsZero() {
+			log.Info(
+				"the session was found to be idle",
+				"cpu usage milicores",
+				cpuUsage.MilliValue(),
+				"idle threshold milicores",
+				cpuUsageIdlenessThreshold.MilliValue(),
+			)
+		}
 		return true
 	}
 


### PR DESCRIPTION
## Describe your changes

This PR reduces the number of requests done to the metrics endpoint and lowers the amount of log generated.

The metrics server does not create metrics data until after 10 seconds of pod container lifetime hence requesting them as soon as the pod is created will only show error message for missing pods from the metrics API.

The same goes for the idleness detection, once it was established that a pod is idle, there's no need to further log that it is is idle.

## Issue ticket number and link

Part of #616
Part of https://github.com/SwissDataScienceCenter/renku/issues/3679
