### PR TITLE
chore: fix regex for publishing charts

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -3,8 +3,7 @@ name: publish-chart
 on:
   push:
     tags:
-      # regex from https://semver.org/
-      - '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+      - "[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,9 @@ jobs:
             make tests
             make test
             make test-e2e
+            helm dep update helm-chart/amalthea
             helm lint helm-chart/amalthea
+            helm dep update helm-chart/amalthea-sessions
             helm lint helm-chart/amalthea-sessions
           push: never
           skipContainerUserIdUpdate: false


### PR DESCRIPTION
I thought that the github workflows supported full regex but they do not. They only support a very simple limited set.