### PR TITLE
fix: typo in reconcile strategy field in CRD

### DIFF
--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -101,7 +101,7 @@ type AmaltheaSessionSpec struct {
 	// - always: This is the expected method of operation for an operator, changes to the spec are always reconciled
 	// - whenHibernatedOrFailed: To avoid interrupting a running session, reconciliation of the child components
 	//   are only done when the session has a Failed or Hibernated status
-	ReconcileStrategy ReconcileStrategy `json:"reconcileSrategy,omitempty"`
+	ReconcileStrategy ReconcileStrategy `json:"reconcileStrategy,omitempty"`
 }
 
 type Session struct {

--- a/bundle/manifests/amalthea.dev_amaltheasessions.yaml
+++ b/bundle/manifests/amalthea.dev_amaltheasessions.yaml
@@ -5353,7 +5353,7 @@ spec:
                   Passed right through to the Statefulset used for the session.
                 type: object
                 x-kubernetes-map-type: atomic
-              reconcileSrategy:
+              reconcileStrategy:
                 default: always
                 description: |-
                   Indicates how Amalthea should reconcile the child resources for a session. This can be problematic because

--- a/config/crd/bases/amalthea.dev_amaltheasessions.yaml
+++ b/config/crd/bases/amalthea.dev_amaltheasessions.yaml
@@ -5353,7 +5353,7 @@ spec:
                   Passed right through to the Statefulset used for the session.
                 type: object
                 x-kubernetes-map-type: atomic
-              reconcileSrategy:
+              reconcileStrategy:
                 default: always
                 description: |-
                   Indicates how Amalthea should reconcile the child resources for a session. This can be problematic because

--- a/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
+++ b/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
@@ -5355,7 +5355,7 @@ spec:
                   Passed right through to the Statefulset used for the session.
                 type: object
                 x-kubernetes-map-type: atomic
-              reconcileSrategy:
+              reconcileStrategy:
                 default: always
                 description: |-
                   Indicates how Amalthea should reconcile the child resources for a session. This can be problematic because


### PR DESCRIPTION
It is a pretty annoying typo. I completely missed it.