### PR TITLE
fix: auth resources and missing priority class

### DIFF
--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -103,6 +103,10 @@ type AmaltheaSessionSpec struct {
 	// - whenHibernatedOrFailed: To avoid interrupting a running session, reconciliation of the child components
 	//   are only done when the session has a Failed or Hibernated status
 	ReconcileStrategy ReconcileStrategy `json:"reconcileStrategy,omitempty"`
+
+	// +optional
+	// The name of the priority class assigned to the session Pod.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 type Session struct {

--- a/api/v1alpha1/auth_templates.go
+++ b/api/v1alpha1/auth_templates.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
@@ -64,6 +65,19 @@ func (as *AmaltheaSession) auth() manifests {
 			),
 			ReadinessProbe: &v1.Probe{ProbeHandler: probeHandler},
 			LivenessProbe:  &v1.Probe{ProbeHandler: probeHandler},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					"memory": resource.MustParse("16Mi"),
+					"cpu":    resource.MustParse("20m"),
+				},
+				Limits: v1.ResourceList{
+					"memory": resource.MustParse("32Mi"),
+					// NOTE: Cpu limit not set on purpose
+					// Without cpu limit if there is spare you can go over the request
+					// If there is no spare cpu then all things get throttled relative to their request
+					// With cpu limits you get throttled when you go over the request always, even with spare capacity
+				},
+			},
 		}
 
 		output.Containers = append(output.Containers, authContainer)
@@ -106,6 +120,19 @@ func (as *AmaltheaSession) auth() manifests {
 			),
 			ReadinessProbe: &v1.Probe{ProbeHandler: probeHandler},
 			LivenessProbe:  &v1.Probe{ProbeHandler: probeHandler},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					"memory": resource.MustParse("16Mi"),
+					"cpu":    resource.MustParse("20m"),
+				},
+				Limits: v1.ResourceList{
+					"memory": resource.MustParse("32Mi"),
+					// NOTE: Cpu limit not set on purpose
+					// Without cpu limit if there is spare you can go over the request
+					// If there is no spare cpu then all things get throttled relative to their request
+					// With cpu limits you get throttled when you go over the request always, even with spare capacity
+				},
+			},
 		}
 
 		output.Containers = append(output.Containers, authContainer)

--- a/bundle/manifests/amalthea.dev_amaltheasessions.yaml
+++ b/bundle/manifests/amalthea.dev_amaltheasessions.yaml
@@ -5353,6 +5353,10 @@ spec:
                   Passed right through to the Statefulset used for the session.
                 type: object
                 x-kubernetes-map-type: atomic
+              priorityClassName:
+                description: The name of the priority class assigned to the session
+                  Pod.
+                type: string
               reconcileStrategy:
                 default: always
                 description: |-

--- a/config/crd/bases/amalthea.dev_amaltheasessions.yaml
+++ b/config/crd/bases/amalthea.dev_amaltheasessions.yaml
@@ -5353,6 +5353,10 @@ spec:
                   Passed right through to the Statefulset used for the session.
                 type: object
                 x-kubernetes-map-type: atomic
+              priorityClassName:
+                description: The name of the priority class assigned to the session
+                  Pod.
+                type: string
               reconcileStrategy:
                 default: always
                 description: |-

--- a/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
+++ b/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
@@ -5355,6 +5355,10 @@ spec:
                   Passed right through to the Statefulset used for the session.
                 type: object
                 x-kubernetes-map-type: atomic
+              priorityClassName:
+                description: The name of the priority class assigned to the session
+                  Pod.
+                type: string
               reconcileStrategy:
                 default: always
                 description: |-


### PR DESCRIPTION
We found this after deploying. We need to priority class to enforce quotas.

Without the resource requests set for the oauth2 proxy we cannot schedule if there is a quota.