### PR TITLE
fix: set the priority class in the statefulset

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -190,6 +190,7 @@ func (cr *AmaltheaSession) StatefulSet() (appsv1.StatefulSet, error) {
 					Tolerations:                  cr.Spec.Tolerations,
 					NodeSelector:                 cr.Spec.NodeSelector,
 					Affinity:                     cr.Spec.Affinity,
+					PriorityClassName:            cr.Spec.PriorityClassName,
 				},
 			},
 		},


### PR DESCRIPTION
I did all of the required changes in #771 except for applying the priority class in the statefulset.