### PR TITLE
fix: clear status after hibernating or resuming

### DIFF
--- a/internal/controller/amaltheasession_controller_test.go
+++ b/internal/controller/amaltheasession_controller_test.go
@@ -431,7 +431,7 @@ var _ = Describe("AmaltheaSession Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(k8sClient.Get(ctx, typeNamespacedName, amaltheasession)).To(Succeed())
 
-			By("Aritificially adding statuses")
+			By("Artificially adding statuses")
 			newTimestamp := metav1.NewTime(time.Now().Round(time.Second))
 			amaltheasession.Status.FailingSince = newTimestamp
 			amaltheasession.Status.IdleSince = newTimestamp
@@ -474,7 +474,7 @@ var _ = Describe("AmaltheaSession Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(k8sClient.Get(ctx, typeNamespacedName, amaltheasession)).To(Succeed())
 
-			By("Aritificially adding statuses")
+			By("Artificially adding statuses")
 			newTimestamp := metav1.NewTime(time.Now().Round(time.Second))
 			amaltheasession.Status.FailingSince = newTimestamp
 			amaltheasession.Status.IdleSince = newTimestamp

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -388,7 +388,7 @@ func Conditions(
 
 // statusCallback modifies an amalthea status based on the reconciliation of different child resources.
 // Certain status updates can only be done based on the current and previous values of child resources,
-// these should take precedence over other statuses dervied only on current values and are applied here.
+// these should take precedence over other statuses derived only on current values and are applied here.
 func (c ChildResourceUpdates) statusCallback(status *amaltheadevv1alpha1.AmaltheaSessionStatus) {
 	if c.Ingress.statusCallback != nil {
 		c.Ingress.statusCallback(status)


### PR DESCRIPTION
Some status fields - most notably, the timestamps that indicate how long the session has been failing, hibernated or idle should be cleared after hibernation or resuming. If this is not done then one cannot successfully resume the session after hibernation (for example).