### PR TITLE
refactor: improve error reporting with regard to image pulling

### DIFF
--- a/test/e2e/general_test.go
+++ b/test/e2e/general_test.go
@@ -258,8 +258,7 @@ var _ = Describe("reconcile strategies", Ordered, func() {
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, typeNamespacedName, amaltheasession)).To(Succeed())
 				g.Expect(amaltheasession.Status.State).To(Equal(amaltheadevv1alpha1.Failed))
-				g.Expect(amaltheasession.Status.Error).To(ContainSubstring("the image"))
-				g.Expect(amaltheasession.Status.Error).To(ContainSubstring("cannot be found"))
+				g.Expect(amaltheasession.Status.Error).To(ContainSubstring("failure to retrieve image for container"))
 			}).WithContext(ctx).WithTimeout(time.Minute * 2).Should(Succeed())
 		})
 


### PR DESCRIPTION
## Describe your changes

Information related to image pulling errors were lost in the original implementation because not all related cases related were handled the same.

Now the original error message is passed back in all cases.

## Issue ticket number and link

Part of #751