### PR TITLE
feat: improve unschedulable error report

### DIFF
--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -328,7 +328,7 @@ func (c ChildResourceUpdates) failureMessage(pod *v1.Pod) string {
 func (c ChildResourceUpdates) warningMessage(pod *v1.Pod) string {
 	for _, condition := range pod.Status.Conditions {
 		if condition.Reason == "Unschedulable" {
-			return fmt.Sprintf("the session cannot be scheduled due to: %s", condition.Message)
+			return fmt.Sprintf("the session cannot be scheduled due to: %s. Please contact an administrator.", condition.Message)
 		}
 	}
 	return ""

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -328,7 +328,7 @@ func (c ChildResourceUpdates) failureMessage(pod *v1.Pod) string {
 func (c ChildResourceUpdates) warningMessage(pod *v1.Pod) string {
 	for _, condition := range pod.Status.Conditions {
 		if condition.Reason == "Unschedulable" {
-			return fmt.Sprintf("the session is requesting more resources than available, the reason is %q, this may correct itself if a Renku admin provisions more resources", condition.Reason)
+			return fmt.Sprintf("the session cannot be scheduled due to: %s", condition.Message)
 		}
 	}
 	return ""

--- a/test/e2e/general_test.go
+++ b/test/e2e/general_test.go
@@ -323,21 +323,21 @@ var _ = Describe("reconcile strategies", Ordered, func() {
 
 		It("should not fail when it is not schedulable for topology given", func(ctx SpecContext) {
 			nodeSelector := corev1.NodeSelector{
-						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							corev1.NodeSelectorTerm{
-								MatchExpressions: []corev1.NodeSelectorRequirement{
-									corev1.NodeSelectorRequirement{
-										Key: "topology",
-										Operator: corev1.NodeSelectorOpIn,
-										Values: []string{"antartica-east1", "antartica-east2"},
-									},
-								},
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      "topology",
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{"antartica-east1", "antartica-east2"},
 							},
 						},
-					}
+					},
+				},
+			}
 			nodeAffinity := corev1.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: ptr.To(nodeSelector),
-				}
+				RequiredDuringSchedulingIgnoredDuringExecution: ptr.To(nodeSelector),
+			}
 			affinity := corev1.Affinity{
 				NodeAffinity: ptr.To(nodeAffinity),
 			}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -96,7 +96,7 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 // UninstallPrometheusOperator uninstalls the prometheus
 func UninstallPrometheusOperator() {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.Command("kubectl", "delete", "-f", url)
+	cmd := exec.Command("kubectl", "delete", "--ignore-not-found", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -105,7 +105,7 @@ func UninstallPrometheusOperator() {
 // UninstallCertManager uninstalls the cert manager
 func UninstallCertManager() {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	cmd := exec.Command("kubectl", "delete", "-f", url)
+	cmd := exec.Command("kubectl", "delete", "--ignore-not-found", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}
@@ -160,7 +160,7 @@ func InstallMetricsServer() error {
 // UninstallMetricsServer uninstalls the metrics server
 func UninstallMetricsServer() {
 	url := fmt.Sprintf(metricsServerURLTmpl, metricsServerVersion)
-	cmd := exec.Command("kubectl", "delete", "-f", url)
+	cmd := exec.Command("kubectl", "delete", "--ignore-not-found", "-f", url)
 	if _, err := Run(cmd); err != nil {
 		warnError(err)
 	}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -57,6 +58,7 @@ const (
 	metricsServerURLTmpl = "https://github.com/kubernetes-sigs/metrics-server/releases/download/%s/components.yaml"
 
 	sdscHelmRepository = "https://swissdatasciencecenter.github.io/helm-charts/"
+	helmRepoName = "renku-test"
 )
 
 func warnError(err error) {
@@ -252,7 +254,7 @@ func InstallHelmChart(ctx context.Context, namespace string, releaseName string,
 		"helm",
 		"repo",
 		"add",
-		"renku",
+		helmRepoName,
 		sdscHelmRepository,
 	)
 	_, err = Run(cmd)
@@ -293,8 +295,11 @@ func InstallHelmChart(ctx context.Context, namespace string, releaseName string,
 
 func UninstallHelmChart(ctx context.Context, namespace string, releaseName string) error {
 	cmd := exec.CommandContext(ctx, "helm", "-n", namespace, "uninstall", releaseName, "--wait", "--timeout", "5m")
-	_, err := Run(cmd)
-	return err
+	_, errUninstall := Run(cmd)
+	cmd = exec.CommandContext(ctx, "helm", "repo", "remove", helmRepoName)
+	_, errRemove := Run(cmd)
+
+	return errors.Join(errUninstall, errRemove)
 }
 
 func getScheme() (*runtime.Scheme, error) {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -58,7 +58,7 @@ const (
 	metricsServerURLTmpl = "https://github.com/kubernetes-sigs/metrics-server/releases/download/%s/components.yaml"
 
 	sdscHelmRepository = "https://swissdatasciencecenter.github.io/helm-charts/"
-	helmRepoName = "renku-test"
+	helmRepoName       = "renku-test"
 )
 
 func warnError(err error) {


### PR DESCRIPTION
## Describe your changes

This PR refactors the handling of unschedulable pods and propagate the information back to the AmaltheaSession.

There are multiple possible reasons for pods not to be scheduled:

- Resource requests outside of system capabilties
- Topological reason (i.e. no nodes matching the selector desired)

As a drive by cleanup, the handling of the helm chart and external resources has also been improved to:
- Allow multiple runs
- Ignore not found resources when deleting