### PR TITLE
feat: surface quota exceede errors on crd

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -363,6 +363,9 @@ func (cr *AmaltheaSession) GetPod(ctx context.Context, clnt client.Client) (*v1.
 	podName := fmt.Sprintf("%s-0", cr.Name)
 	key := types.NamespacedName{Name: podName, Namespace: cr.GetNamespace()}
 	err := clnt.Get(ctx, key, &pod)
+	if err != nil {
+		return nil, err
+	}
 	return &pod, err
 }
 

--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -358,7 +358,7 @@ func (cr *AmaltheaSession) NeedsDeletion() bool {
 		hibernatedDuration > cr.Spec.Culling.MaxHibernatedDuration.Duration
 }
 
-func (cr *AmaltheaSession) Pod(ctx context.Context, clnt client.Client) (*v1.Pod, error) {
+func (cr *AmaltheaSession) GetPod(ctx context.Context, clnt client.Client) (*v1.Pod, error) {
 	pod := v1.Pod{}
 	podName := fmt.Sprintf("%s-0", cr.Name)
 	key := types.NamespacedName{Name: podName, Namespace: cr.GetNamespace()}

--- a/bundle/manifests/amalthea.clusterserviceversion.yaml
+++ b/bundle/manifests/amalthea.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-11T10:47:59Z"
+    createdAt: "2025-03-12T09:35:30Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: amalthea.v0.0.1

--- a/bundle/manifests/amalthea.clusterserviceversion.yaml
+++ b/bundle/manifests/amalthea.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-01-29T18:19:02Z"
+    createdAt: "2025-03-11T10:47:59Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: amalthea.v0.0.1
@@ -90,6 +90,15 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - events
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - persistentvolumeclaims
           verbs:
           - create
@@ -120,7 +129,6 @@ spec:
           - update
           - watch
         - apiGroups:
-          - ""
           - metrics.k8s.io
           resources:
           - pods

--- a/bundle/manifests/amalthea.dev_amaltheasessions.yaml
+++ b/bundle/manifests/amalthea.dev_amaltheasessions.yaml
@@ -11,6 +11,9 @@ spec:
     kind: AmaltheaSession
     listKind: AmaltheaSessionList
     plural: amaltheasessions
+    shortNames:
+    - ams
+    - amss
     singular: amaltheasession
   scope: Namespaced
   versions:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: example.com/amalthea
-  newTag: v0.0.1
+  newName: controller
+  newTag: latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -44,6 +44,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create
@@ -74,7 +83,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
   - metrics.k8s.io
   resources:
   - pods

--- a/helm-chart/amalthea-sessions/templates/manager-rbac.yaml
+++ b/helm-chart/amalthea-sessions/templates/manager-rbac.yaml
@@ -66,6 +66,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: [delete]
+- apiGroups: [""]
+  resources: [events]
+  verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.clusterScoped }}

--- a/internal/controller/amaltheasession_controller.go
+++ b/internal/controller/amaltheasession_controller.go
@@ -55,6 +55,7 @@ const secretCleanupFinalizerName = "amalthea.dev/secrets-finalizer"
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=metrics.k8s.io,resources=pods,verbs=get;list;watch

--- a/internal/controller/cull.go
+++ b/internal/controller/cull.go
@@ -32,7 +32,7 @@ func updateHibernationState(ctx context.Context, r *AmaltheaSessionReconciler, a
 	status := amaltheasession.Status
 	log := log.FromContext(ctx)
 	if !amaltheasession.Spec.Hibernated {
-		pod, err := amaltheasession.Pod(ctx, r.Client)
+		pod, err := amaltheasession.GetPod(ctx, r.Client)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -19,6 +19,9 @@ var cpuUsageIdlenessThreshold resource.Quantity = *resource.NewMilliQuantity(300
 func containerCounts(pod *v1.Pod) (amaltheadevv1alpha1.ContainerCounts, amaltheadevv1alpha1.ContainerCounts) {
 	initCounts := amaltheadevv1alpha1.ContainerCounts{}
 	counts := amaltheadevv1alpha1.ContainerCounts{}
+	if pod == nil {
+		return initCounts, counts
+	}
 	for _, container := range pod.Status.InitContainerStatuses {
 		containerCompleted := container.State.Terminated != nil && container.State.Terminated.ExitCode == 0 && container.State.Terminated.Reason == "Completed"
 		initCounts.Total += 1


### PR DESCRIPTION
trying to "Owns()" events doesn't work, you don't get stateful set events..

The current solution works, though might have performance implications due to fetching events for each statefulset in the reconcile loop.

The status on a session would look like:
```
status:
  conditions:
    - lastTransitionTime: '2025-03-07T09:35:12Z'
      message: The session is hibernated
      reason: Hibernated
      status: 'False'
      type: Ready
    - lastTransitionTime: '2025-03-06T09:30:28Z'
      message: The ingress is setup and operational
      reason: IngressOperational
      status: 'True'
      type: RoutingReady
  containerCounts: {}
  error: Quota exceeded
  idle: false
  initContainerCounts: {}
  state: Failed
  url: https://renku-ci-am-895.dev.renku.ch/sessions/john-doe-01adadc97abf/lab/
```