### PR TITLE
feat: add image pull policy to the CRD

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -110,7 +110,7 @@ func (cr *AmaltheaSession) StatefulSet() (appsv1.StatefulSet, error) {
 	sessionContainer := v1.Container{
 		Image:                    session.Image,
 		Name:                     SessionContainerName,
-		ImagePullPolicy:          v1.PullIfNotPresent,
+		ImagePullPolicy:          cr.Spec.Session.ImagePullPolicy,
 		Args:                     session.Args,
 		Command:                  session.Command,
 		Env:                      session.Env,

--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -116,7 +116,7 @@ type AmaltheaSessionSpec struct {
 type Session struct {
 	Image string `json:"image"`
 	// +optional
-	// +kubebuilder:default:=IfNotPresent
+	// +kubebuilder:default:=Always
 	// The image pull policy to apply to the session image
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// The command to run in the session container, if omitted it will use the Docker image ENTRYPOINT

--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -115,6 +115,10 @@ type AmaltheaSessionSpec struct {
 
 type Session struct {
 	Image string `json:"image"`
+	// +optional
+	// +kubebuilder:default:=IfNotPresent
+	// The image pull policy to apply to the session image
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// The command to run in the session container, if omitted it will use the Docker image ENTRYPOINT
 	Command []string `json:"command,omitempty"`
 	// The arguments to run in the session container, if omitted it will use the Docker image CMD

--- a/bundle/manifests/amalthea.dev_amaltheasessions.yaml
+++ b/bundle/manifests/amalthea.dev_amaltheasessions.yaml
@@ -6182,6 +6182,10 @@ spec:
                     type: array
                   image:
                     type: string
+                  imagePullPolicy:
+                    default: IfNotPresent
+                    description: The image pull policy to apply to the session image
+                    type: string
                   port:
                     default: 8000
                     description: |-

--- a/bundle/manifests/amalthea.dev_amaltheasessions.yaml
+++ b/bundle/manifests/amalthea.dev_amaltheasessions.yaml
@@ -6183,7 +6183,7 @@ spec:
                   image:
                     type: string
                   imagePullPolicy:
-                    default: IfNotPresent
+                    default: Always
                     description: The image pull policy to apply to the session image
                     type: string
                   port:

--- a/config/crd/bases/amalthea.dev_amaltheasessions.yaml
+++ b/config/crd/bases/amalthea.dev_amaltheasessions.yaml
@@ -6182,6 +6182,10 @@ spec:
                     type: array
                   image:
                     type: string
+                  imagePullPolicy:
+                    default: IfNotPresent
+                    description: The image pull policy to apply to the session image
+                    type: string
                   port:
                     default: 8000
                     description: |-

--- a/config/crd/bases/amalthea.dev_amaltheasessions.yaml
+++ b/config/crd/bases/amalthea.dev_amaltheasessions.yaml
@@ -6183,7 +6183,7 @@ spec:
                   image:
                     type: string
                   imagePullPolicy:
-                    default: IfNotPresent
+                    default: Always
                     description: The image pull policy to apply to the session image
                     type: string
                   port:

--- a/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
+++ b/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
@@ -6185,7 +6185,7 @@ spec:
                   image:
                     type: string
                   imagePullPolicy:
-                    default: IfNotPresent
+                    default: Always
                     description: The image pull policy to apply to the session image
                     type: string
                   port:

--- a/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
+++ b/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
@@ -6184,6 +6184,10 @@ spec:
                     type: array
                   image:
                     type: string
+                  imagePullPolicy:
+                    default: IfNotPresent
+                    description: The image pull policy to apply to the session image
+                    type: string
                   port:
                     default: 8000
                     description: |-


### PR DESCRIPTION
Adds a new field to the CRD.

The default is `IfNotPresent` because  that is what we had hardcoded before in the code - so this way we remain compatible.