### PR TITLE
fix: make image pull policy an enum

### DIFF
--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -117,6 +117,7 @@ type Session struct {
 	Image string `json:"image"`
 	// +optional
 	// +kubebuilder:default:=Always
+	// +kubebuilder:validation:Enum={Always,Never,IfNotPresent}
 	// The image pull policy to apply to the session image
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// The command to run in the session container, if omitted it will use the Docker image ENTRYPOINT

--- a/bundle/manifests/amalthea.dev_amaltheasessions.yaml
+++ b/bundle/manifests/amalthea.dev_amaltheasessions.yaml
@@ -6185,6 +6185,10 @@ spec:
                   imagePullPolicy:
                     default: Always
                     description: The image pull policy to apply to the session image
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
                     type: string
                   port:
                     default: 8000

--- a/config/crd/bases/amalthea.dev_amaltheasessions.yaml
+++ b/config/crd/bases/amalthea.dev_amaltheasessions.yaml
@@ -6185,6 +6185,10 @@ spec:
                   imagePullPolicy:
                     default: Always
                     description: The image pull policy to apply to the session image
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
                     type: string
                   port:
                     default: 8000

--- a/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
+++ b/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
@@ -6187,6 +6187,10 @@ spec:
                   imagePullPolicy:
                     default: Always
                     description: The image pull policy to apply to the session image
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
                     type: string
                   port:
                     default: 8000


### PR DESCRIPTION
I thought if I just use the struct from the official k8s client it would turn into an enum magically but it will not. I was missing an kubebuilder comment to make this happen.