### PR TITLE
chore: update to go 1.24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 		"ghcr.io/devcontainers-contrib/features/poetry:2": {},
 		"ghcr.io/dhoeric/features/k9s:1": {},
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.23"
+			"version": "1.24"
 		}
 	},
 	"containerEnv": {"LOCALBIN": "/${containerWorkspaceFolder}/bin_devcontainer"}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/SwissDataScienceCenter/amalthea
 
-go 1.23.0
-
-toolchain go1.23.2
+go 1.24.3
 
 require (
 	github.com/go-git/go-git/v5 v5.14.0


### PR DESCRIPTION
This will allow us the rest of the updates from dependabot to merge. There is some weird problem with golangci lint because it is using 1.24 but  the project isnt or vice-versa.

Plus it is good to be up to date.