### PR TITLE
refactor:crd deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	echo "# This manifest is auto-generated from the makefile do not edit manually." >> $(HELM_CRD_TEMPLATE)
+	echo "# This manifest is auto-generated from the makefile do not edit manually." > $(HELM_CRD_TEMPLATE)
 	cat config/crd/bases/*yaml >> $(HELM_CRD_TEMPLATE)
 
 .PHONY: generate

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ all: build
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
 
-HELM_CRD_TEMPLATE ?= helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
+HELM_CRD_TEMPLATE ?= helm-chart/amalthea-sessions/crds/amaltheasession.yaml
 
 .PHONY: help
 help: ## Display this help.
@@ -101,10 +101,8 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	echo "{{- if .Values.deployCrd -}}" > $(HELM_CRD_TEMPLATE)
 	echo "# This manifest is auto-generated from the makefile do not edit manually." >> $(HELM_CRD_TEMPLATE)
 	cat config/crd/bases/*yaml >> $(HELM_CRD_TEMPLATE)
-	echo "{{- end }}" >> $(HELM_CRD_TEMPLATE)
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/helm-chart/amalthea-sessions/crds/amaltheasession.yaml
+++ b/helm-chart/amalthea-sessions/crds/amaltheasession.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.deployCrd -}}
 # This manifest is auto-generated from the makefile do not edit manually.
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -6493,4 +6492,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end }}

--- a/helm-chart/amalthea-sessions/templates/manager-rbac.yaml
+++ b/helm-chart/amalthea-sessions/templates/manager-rbac.yaml
@@ -47,15 +47,20 @@ rules:
   resources: [pods]
   verbs: [get, list, watch]
 # Amalthea: child resources we produce
-# Note that we do not patch/update/delete them ever.
 - apiGroups:
   - ""
-  - apps
-  - networking.k8s.io
   resources:
-    - statefulsets
     - persistentvolumeclaims
     - services
+  verbs: [create, get, list, watch]
+- apiGroups:
+  - apps
+  resources:
+    - statefulsets
+  verbs: [create, get, list, watch]
+- apiGroups:
+  - networking.k8s.io
+  resources:
     - ingresses
   verbs: [create, get, list, watch, patch, update]
 # Required for hibernating sessions

--- a/helm-chart/amalthea-sessions/values.yaml
+++ b/helm-chart/amalthea-sessions/values.yaml
@@ -25,8 +25,6 @@ controllerManager:
 kubernetesClusterDomain: cluster.local
 # If set to true then the operator will watch and operate in all namespaces
 clusterScoped: false
-# Whether to install the CRD
-deployCrd: true
 # Whether to install the dependencies or not
 deploy:
   csiRclone: false

--- a/helm-chart/amalthea/crds/jupyterserver.yaml
+++ b/helm-chart/amalthea/crds/jupyterserver.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.deployCrd -}}
 # This manifest is auto-generated from controller/crds/jupyter_server.yaml, do not modify.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -307,4 +306,3 @@ spec:
               default:
                 children: {}
                 mainPod: {}
-{{- end }}

--- a/helm-chart/amalthea/templates/rbac/_rbac_rules.tpl
+++ b/helm-chart/amalthea/templates/rbac/_rbac_rules.tpl
@@ -26,15 +26,21 @@
   # Note that we do not patch/update/delete them ever.
   - apiGroups:
       - ""
-      - apps
-      - networking.k8s.io
     resources:
-      - statefulsets
       - persistentvolumeclaims
       - services
-      - ingresses
       - secrets
       - configmaps
+    verbs: [create, get, list, watch]
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs: [create, get, list, watch]
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
     verbs: [create, get, list, watch]
 
   # Required for hibernating sessions

--- a/helm-chart/amalthea/values.schema.json
+++ b/helm-chart/amalthea/values.schema.json
@@ -66,10 +66,6 @@
             },
             "type": "object"
         },
-        "deployCrd": {
-            "description": "Should the helm chart apply the k8s CRD.",
-            "type": "boolean"
-        },
         "networkPolicies": {
             "description": "Enable and configure network policies for the controller and jupyter servers.",
             "type": "object",
@@ -436,7 +432,6 @@
     },
     "required": [
         "scope",
-        "deployCrd",
         "networkPolicies",
         "kopf",
         "extraChildResources",

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -35,8 +35,6 @@ scope:
   #    will only operate in the namespace where the helm chart is deployed.
   # namespaces: ["default"]
 
-deployCrd: true # whether to deploy the jupyterserver CRD
-
 networkPolicies:
   # # Enable sensible, default network policies. Note that until cluster-wide
   # # network policies are available in Kubernetes (https://github.com/kubernetes/enhancements/issues/2091),


### PR DESCRIPTION
## Describe your changes

This PR refactors the CRD deployment part of the amalthea and amalthea-session helm charts.

The management of the CRD, while looking simple, is in fact quite complex in its consequences.
Hence we will follow the current recommendation of the Helm maintainers.
More information about the reasoning can be found at:

https://github.com/helm/community/blob/main/hips/hip-0011.md

The RBAC cleanup will also allow for deployment on OpenShift.