### PR TITLE
fix: missing mismatched rbac rules

### DIFF
--- a/bundle/manifests/amalthea.clusterserviceversion.yaml
+++ b/bundle/manifests/amalthea.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-05-26T12:51:04Z"
+    createdAt: "2025-06-25T07:56:15Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: amalthea.v0.0.1
@@ -100,9 +100,9 @@ spec:
           - ""
           resources:
           - persistentvolumeclaims
+          - services
           verbs:
           - create
-          - delete
           - get
           - list
           - patch
@@ -117,17 +117,6 @@ spec:
           - delete
           - list
           - patch
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - services
-          verbs:
-          - create
-          - get
-          - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - metrics.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,9 +54,9 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
+  - services
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
@@ -71,17 +71,6 @@ rules:
   - delete
   - list
   - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - metrics.k8s.io

--- a/helm-chart/amalthea-sessions/templates/manager-rbac.yaml
+++ b/helm-chart/amalthea-sessions/templates/manager-rbac.yaml
@@ -57,7 +57,7 @@ rules:
     - persistentvolumeclaims
     - services
     - ingresses
-  verbs: [create, get, list, watch]
+  verbs: [create, get, list, watch, patch, update]
 # Required for hibernating sessions
 - apiGroups: ["apps"]
   resources: ["statefulsets"]

--- a/internal/controller/amaltheasession_controller.go
+++ b/internal/controller/amaltheasession_controller.go
@@ -53,7 +53,7 @@ const secretCleanupFinalizerName = "amalthea.dev/secrets-finalizer"
 // +kubebuilder:rbac:groups=amalthea.dev,resources=amaltheasessions/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=list;watch;delete;create;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch


### PR DESCRIPTION
The rbac rules in the helm chart are not automatically updated. I opened an issue for this. For now I updated/synced them manually.