### PR TITLE
feat: specify a service account for the sessions

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -195,6 +195,7 @@ func (cr *AmaltheaSession) StatefulSet() (appsv1.StatefulSet, error) {
 					Labels: labels,
 				},
 				Spec: v1.PodSpec{
+					ServiceAccountName:           cr.Spec.ServiceAccountName,
 					EnableServiceLinks:           ptr.To(false),
 					AutomountServiceAccountToken: ptr.To(false),
 					SecurityContext:              &v1.PodSecurityContext{FSGroup: &cr.Spec.Session.RunAsGroup},

--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -111,6 +111,10 @@ type AmaltheaSessionSpec struct {
 	// +optional
 	// List of secrets that contain credentials for pulling private images
 	ImagePullSecrets []SessionSecretRef `json:"imagePullSecrets,omitempty"`
+
+	// +optional
+	// The name of the service account that should be used for the session Pod
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 type Session struct {

--- a/bundle/manifests/amalthea.dev_amaltheasessions.yaml
+++ b/bundle/manifests/amalthea.dev_amaltheasessions.yaml
@@ -6016,6 +6016,10 @@ spec:
                 - always
                 - whenFailedOrHibernated
                 type: string
+              serviceAccountName:
+                description: The name of the service account that should be used for
+                  the session Pod
+                type: string
               session:
                 description: Specification for the main session container that the
                   user will access and use

--- a/config/crd/bases/amalthea.dev_amaltheasessions.yaml
+++ b/config/crd/bases/amalthea.dev_amaltheasessions.yaml
@@ -6016,6 +6016,10 @@ spec:
                 - always
                 - whenFailedOrHibernated
                 type: string
+              serviceAccountName:
+                description: The name of the service account that should be used for
+                  the session Pod
+                type: string
               session:
                 description: Specification for the main session container that the
                   user will access and use

--- a/helm-chart/amalthea-sessions/crds/amaltheasession.yaml
+++ b/helm-chart/amalthea-sessions/crds/amaltheasession.yaml
@@ -6017,6 +6017,10 @@ spec:
                 - always
                 - whenFailedOrHibernated
                 type: string
+              serviceAccountName:
+                description: The name of the service account that should be used for
+                  the session Pod
+                type: string
               session:
                 description: Specification for the main session container that the
                   user will access and use


### PR DESCRIPTION
This is required for openshift.

Assigining a service account to the session is the only way to allow a different SCC (security context constraint) to be used by the sessions. With this we can potentially use a service account that can use a SCC that allows us to run as any non root rather than the usual openshift constraint.

