### PR TITLE
chore: fix upload of snyk image check reports

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -50,28 +50,27 @@ jobs:
         continue-on-error: true
         with:
           image: ${{ steps.publish-chart.outputs.amalthea-sessions-image}}
-          args: --file=./Dockerfile --severity-threshold=high --sarif-file-output=as.sarif
+          args: --file=./Dockerfile --severity-threshold=high
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      - name: List files
-        run: |
-          pwd
-          ls -la
       - name: Upload Snyk report
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: as.sarif
+          sarif_file: snyk.sarif
           category: snyk_amalthea-sessions
+      - name: Remove old sarif files if they exist
+        run: |
+          rm -rf snyk.sarif
       - name: Scan sidecars image
         uses: snyk/actions/docker@master
         continue-on-error: true
         with:
           image: ${{ steps.publish-chart.outputs.amalthea-sidecars-image}}
-          args: --file=./sidecars.Dockerfile --severity-threshold=high --sarif-file-output=sc.sarif
+          args: --file=./sidecars.Dockerfile --severity-threshold=high
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       - name: Upload Snyk report
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: sc.sarif
+          sarif_file: snyk.sarif
           category: snyk_sidecars


### PR DESCRIPTION
For some reason snyk ignores the option that is supposed to make the file name be a specific value and not snyk.sarif.

I checked the docs and it seems that we are using the right flag that is supposed to give us a custom name for the sarif file. But the snyk action keeps producing only a `snyk.sarif` file.