### PR TITLE
fix: revert "refactor:crd deployment (#952)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ all: build
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
 
-HELM_CRD_TEMPLATE ?= helm-chart/amalthea-sessions/crds/amaltheasession.yaml
+HELM_CRD_TEMPLATE ?= helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
 
 .PHONY: help
 help: ## Display this help.
@@ -101,8 +101,10 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	echo "# This manifest is auto-generated from the makefile do not edit manually." > $(HELM_CRD_TEMPLATE)
+	echo "{{- if .Values.deployCrd -}}" > $(HELM_CRD_TEMPLATE)
+	echo "# This manifest is auto-generated from the makefile do not edit manually." >> $(HELM_CRD_TEMPLATE)
 	cat config/crd/bases/*yaml >> $(HELM_CRD_TEMPLATE)
+	echo "{{- end }}" >> $(HELM_CRD_TEMPLATE)
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
+++ b/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployCrd -}}
 # This manifest is auto-generated from the makefile do not edit manually.
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -6496,3 +6497,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/helm-chart/amalthea-sessions/values.yaml
+++ b/helm-chart/amalthea-sessions/values.yaml
@@ -25,6 +25,8 @@ controllerManager:
 kubernetesClusterDomain: cluster.local
 # If set to true then the operator will watch and operate in all namespaces
 clusterScoped: false
+# Whether to install the CRD
+deployCrd: true
 # Whether to install the dependencies or not
 deploy:
   csiRclone: false

--- a/helm-chart/amalthea/templates/crd.yaml
+++ b/helm-chart/amalthea/templates/crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployCrd -}}
 # This manifest is auto-generated from controller/crds/jupyter_server.yaml, do not modify.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -306,3 +307,4 @@ spec:
               default:
                 children: {}
                 mainPod: {}
+{{- end }}

--- a/helm-chart/amalthea/values.schema.json
+++ b/helm-chart/amalthea/values.schema.json
@@ -66,6 +66,10 @@
             },
             "type": "object"
         },
+        "deployCrd": {
+            "description": "Should the helm chart apply the k8s CRD.",
+            "type": "boolean"
+        },
         "networkPolicies": {
             "description": "Enable and configure network policies for the controller and jupyter servers.",
             "type": "object",
@@ -432,6 +436,7 @@
     },
     "required": [
         "scope",
+        "deployCrd",
         "networkPolicies",
         "kopf",
         "extraChildResources",

--- a/helm-chart/amalthea/values.yaml
+++ b/helm-chart/amalthea/values.yaml
@@ -35,6 +35,8 @@ scope:
   #    will only operate in the namespace where the helm chart is deployed.
   # namespaces: ["default"]
 
+deployCrd: true # whether to deploy the jupyterserver CRD
+
 networkPolicies:
   # # Enable sensible, default network policies. Note that until cluster-wide
   # # network policies are available in Kubernetes (https://github.com/kubernetes/enhancements/issues/2091),


### PR DESCRIPTION
This partially reverts commit a6bd2a4ade4991eff96e5a49bc2b47f268fb461a.

The things that are not reverted and are left in are changes to the rbac role. For some reason openshift was really pick about combining multiple api groups in one role stanza. 