### PR TITLE
fix: use bitnami legacy for oauth2 proxy image

### DIFF
--- a/api/v1alpha1/auth_templates.go
+++ b/api/v1alpha1/auth_templates.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const authproxyImage string = "bitnami/oauth2-proxy:7.6.0"
+const authproxyImage string = "harbor.renkulab.io/bitnami-mirror/oauth2-proxy:7.6.0"
 
 func (as *AmaltheaSession) auth() (manifests, error) {
 	output := manifests{}


### PR DESCRIPTION
This is because bitnami is deprecating all free images.