### PR TITLE
Fix: Preserve `WSTUNNEL_SECRET` during reconciliation to prevent session disruption

### DIFF
--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -242,8 +242,18 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 				}
 				fallthrough
 			case amaltheadevv1alpha1.Always:
+				// Preserve existing random tunnel secret values when updating
+				preservedStringData := make(map[string]string)
+				for k, v := range desired.StringData {
+					preservedStringData[k] = v
+				}
+				if current.Data != nil {
+					if existingTunnel, exists := current.Data["WSTUNNEL_SECRET"]; exists {
+						preservedStringData["WSTUNNEL_SECRET"] = string(existingTunnel)
+					}
+				}
 				current.Data = desired.Data
-				current.StringData = desired.StringData
+				current.StringData = preservedStringData
 			default:
 				return fmt.Errorf("attempting to reconcile secret with unknown stategy %s", strategy)
 			}


### PR DESCRIPTION
PR stack:
* (base) #984
    * #991
      * #997
        * #1001
          * #1005 
            * (this) #1006

This PR addresses an issue where the `WSTUNNEL_SECRET` used for remote sessions was being overwritten during each reconciliation loop. This behavior leads to problems for remote sessions leveraging Firecrest on a distant system:

 **Secret Mismatch**: The `WSTUNNEL_SECRET` is generated by Firecrest on the remote system (e.g., Slurm) to secure the tunnel connection. If Amalthea regenerates and overwrites this secret during a reconciliation loop, it creates a mismatch between the secret known to the Kubernetes pod and the secret on the remote system. This can lead to a broken tunnel connection and an unusable remote session.

**Solution:**

The fix is implemented in `internal/controller/children.go` within the `Reconcile` method for `v1.Secret` resources. Specifically, when reconciling the internal secret that contains the `WSTUNNEL_SECRET`, the existing `WSTUNNEL_SECRET` value is now preserved if it already exists.

This approach ensures that:
*   The `WSTUNNEL_SECRET` generated by Firecrest on the distant system remains unchanged within the Kubernetes secret during subsequent reconciliation loops.
*   The integrity of the remote session tunnel is maintained, preventing disruptions due to secret mismatches.
*   The design aligns with the understanding that the remote secret is a static credential provisioned by an external system for the duration of the session.

**Rationale for the method used**

The `internal/controller/children.go` file is responsible for the reconciliation logic of child resources managed by the Amalthea operator. Placing the logic to preserve the `WSTUNNEL_SECRET` within the `Reconcile` method for `v1.Secret` ensures that:

*   The preservation logic is applied precisely at the point where the internal secret is created or updated.
*   It directly addresses the issue of unintended secret overwrites during the reconciliation process.
*   This location is consistent with how other child resource properties are handled and updated, making the change cohesive with the existing controller logic.

**Open Discussion Points:**

*   **Secret Change on Pause/Restart**: Should the `WSTUNNEL_SECRET` be regenerated if a session is paused and then restarted? This depends on whether a restart implies a new remote allocation (favoring regeneration for security/alignment) or simply resuming the same allocation (favoring preservation for stability).
*   **Reconcile Strategy vs. Secret Preservation**: Given the `amaltheav1alpha1dev.Always` reconciliation strategy, is it appropriate to preserve the `WSTUNNEL_SECRET`? While "always reconcile" implies bringing the live state in line with the desired state, for externally managed, dynamically generated credentials like this secret, stability is crucial. The current approach treats the existing secret as part of the desired state, acknowledging its external origin and the need for consistency. Explicit rotation mechanisms would be needed if full reconciliation (including regeneration) were desired for this specific secret.