### PR TITLE
fix: Use HostToContainer in DC mounts

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -519,6 +519,8 @@ func (as *AmaltheaSession) DataSources() ([]v1.PersistentVolumeClaim, []v1.Volum
 	pvcs := []v1.PersistentVolumeClaim{}
 	vols := []v1.Volume{}
 	volMounts := []v1.VolumeMount{}
+	// Can't take the address of a constant, we have to go through a variable
+	mountPropagationMode := v1.MountPropagationHostToContainer
 	for ids, ds := range as.Spec.DataSources {
 		pvcName := fmt.Sprintf("%s%s-ds-%d", prefix, as.Name, ids)
 		switch ds.Type {
@@ -561,9 +563,10 @@ func (as *AmaltheaSession) DataSources() ([]v1.PersistentVolumeClaim, []v1.Volum
 			volMounts = append(
 				volMounts,
 				v1.VolumeMount{
-					Name:      pvcName,
-					ReadOnly:  readOnly,
-					MountPath: ds.MountPath,
+					Name:             pvcName,
+					ReadOnly:         readOnly,
+					MountPath:        ds.MountPath,
+					MountPropagation: &mountPropagationMode,
 				},
 			)
 		default:

--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -519,8 +519,6 @@ func (as *AmaltheaSession) DataSources() ([]v1.PersistentVolumeClaim, []v1.Volum
 	pvcs := []v1.PersistentVolumeClaim{}
 	vols := []v1.Volume{}
 	volMounts := []v1.VolumeMount{}
-	// Can't take the address of a constant, we have to go through a variable
-	mountPropagationMode := v1.MountPropagationHostToContainer
 	for ids, ds := range as.Spec.DataSources {
 		pvcName := fmt.Sprintf("%s%s-ds-%d", prefix, as.Name, ids)
 		switch ds.Type {
@@ -566,7 +564,7 @@ func (as *AmaltheaSession) DataSources() ([]v1.PersistentVolumeClaim, []v1.Volum
 					Name:             pvcName,
 					ReadOnly:         readOnly,
 					MountPath:        ds.MountPath,
-					MountPropagation: &mountPropagationMode,
+					MountPropagation: ptr.To(v1.MountPropagationHostToContainer),
 				},
 			)
 		default:


### PR DESCRIPTION
This is needed to support rebinding in case of the csi driver restarting.