### PR TITLE
fix: preserve source URL path when deriving session URL

### DIFF
--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -528,7 +528,7 @@ func (a *AmaltheaSession) GetURL() *url.URL {
 	// NOTE: This preserves the search query and fragment found in Spec.Session.URLPath
 	sessionURL, err := url.Parse(path)
 	if err != nil {
-		// NOTE: this should really not happen because we prepend '/' just above
+		// NOTE: this should not happen, but invalid characters may have escaped validation
 		return &url.URL{
 			Scheme: urlScheme,
 			Path:   path,


### PR DESCRIPTION
Closes #1062.

Tested here -> https://renku-ci-am-1063.dev.renku.ch/p/flora.thiebaut/flora-test#launcher-01KFFVJ00G505KYCWYD5HNADY0
See that the query parameter is preserved when opening the session.

/deploy