### PR TITLE
fix: handle default priority class and remote SA

### DIFF
--- a/helm-chart/amalthea-sessions/templates/priorityclass.yaml
+++ b/helm-chart/amalthea-sessions/templates/priorityclass.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.deploy.priorityClass -}}
+---
+apiVersion: scheduling.k8s.io/v1
+description: Renku default resource quota priority class
+kind: PriorityClass
+metadata:
+  labels:
+    app: renku
+  name: renku-user-sessions-priority
+preemptionPolicy: Never
+value: 100
+{{- end }}

--- a/helm-chart/amalthea-sessions/templates/serviceaccount.yaml
+++ b/helm-chart/amalthea-sessions/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,3 +10,107 @@ metadata:
   {{- include "amalthea-sessions.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}
+
+{{- if .Values.deploy.remoteServiceAccount }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: renku-remote-session-manager
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: amalthea
+    app.kubernetes.io/part-of: amalthea
+  {{- include "amalthea-sessions.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.controllerManager.remoteServiceAccount.annotations | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: renku-remote-session-manager-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- include "amalthea-sessions.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - services
+      - endpoints
+      - secrets
+      - priorityclasses
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - secrets
+    verbs:
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - resourcequotas
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - scheduling.k8s.io
+    resources:
+      - priorityclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - amalthea.dev
+    resources:
+      - amaltheasessions
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+      - list
+      - get
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: renku-remote-session-manager-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: amalthea
+    app.kubernetes.io/part-of: amalthea
+  {{- include "amalthea-sessions.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'renku-remote-session-manager-role'
+subjects:
+- kind: ServiceAccount
+  name: 'renku-remote-session-manager'
+  namespace: '{{ .Release.Namespace }}'
+
+{{- end }}

--- a/helm-chart/amalthea-sessions/values.yaml
+++ b/helm-chart/amalthea-sessions/values.yaml
@@ -28,6 +28,8 @@ controllerManager:
   replicas: 1
   serviceAccount:
     annotations: {}
+  remoteServiceAccount:
+    annotations: {}
 kubernetesClusterDomain: cluster.local
 # If set to true then the operator will watch and operate in all namespaces
 clusterScoped: false
@@ -35,6 +37,10 @@ clusterScoped: false
 deployCrd: true
 # Whether to install the dependencies or not
 deploy:
+  priorityClass: false
+  # Whether to create a default resource quota priority class named `renku-user-sessions-priority`
+  remoteServiceAccount: false
+  # Whether to create a service account for a remote Renku portal to connect to the cluster running this operator.
   csiRclone: false
 
 # rcloneStorageClass is the storage class name for the csi-rclone Helm chart


### PR DESCRIPTION
Add flags to create:
 - a default resource quota priority class for renku user sessions
 - a service account with a role and role binding to allow a remote renku portal to manage Amalthea sessions.