### PR TITLE
feat: support setting samesite cookie param

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -48,6 +48,7 @@ const TunnelPort int32 = 65531
 var sidecarsImage string = getSidecarsImage()
 var rcloneStorageClass string = getStorageClass()
 var rcloneDefaultStorage resource.Quantity = resource.MustParse("1Gi")
+var useNoneSameSiteSessionCookie = getUseNoneSameSiteSessionCookie()
 
 const rcloneStorageSecretNameAnnotation = "csi-rclone.dev/secretName"
 
@@ -604,6 +605,10 @@ func getSidecarsImage() string {
 		sc = "renku/sidecars:latest"
 	}
 	return sc
+}
+
+func getUseNoneSameSiteSessionCookie() bool {
+	return strings.ToLower(os.Getenv("USE_NONE_SAME_SITE_SESSION_COOKIE")) == "true"
 }
 
 // InternalSecretName returns the name of the secret that is a child

--- a/api/v1alpha1/auth_templates.go
+++ b/api/v1alpha1/auth_templates.go
@@ -47,6 +47,10 @@ func (as *AmaltheaSession) auth() (manifests, error) {
 				Port: intstr.FromInt32(authenticatedPort),
 			},
 		}
+		sameSiteCookieFlag := "strict"
+		if useNoneSameSiteSessionCookie {
+			sameSiteCookieFlag = "none"
+		}
 		oauth2ProxyContainer := v1.Container{
 			Image: authproxyImage,
 			Name:  "oauth2-proxy",
@@ -59,6 +63,7 @@ func (as *AmaltheaSession) auth() (manifests, error) {
 				fmt.Sprintf("--http-address=:%d", authenticatedPort),
 				"--silence-ping-logging",
 				"--config=/etc/oauth2-proxy/" + auth.SecretRef.Key,
+				fmt.Sprintf("--cookie-samesite=%s", sameSiteCookieFlag),
 			},
 			VolumeMounts: append(
 				[]v1.VolumeMount{
@@ -89,6 +94,9 @@ func (as *AmaltheaSession) auth() (manifests, error) {
 
 		output.Containers = append(output.Containers, oauth2ProxyContainer)
 	case Token:
+		if useNoneSameSiteSessionCookie {
+			return output, fmt.Errorf("cannot set the same site cookie parameter for anonymous sessions")
+		}
 		volName := fmt.Sprintf("%sproxy-configuration-secret", prefix)
 		output.Volumes = append(output.Volumes, v1.Volume{
 			Name: volName,
@@ -143,6 +151,10 @@ func (as *AmaltheaSession) auth() (manifests, error) {
 				Port: intstr.FromInt32(authenticatedPort),
 			},
 		}
+		sameSiteCookieFlag := "strict"
+		if useNoneSameSiteSessionCookie {
+			sameSiteCookieFlag = "none"
+		}
 		oauth2ProxyContainer := v1.Container{
 			Image: authproxyImage,
 			Name:  "oauth2-proxy",
@@ -154,6 +166,7 @@ func (as *AmaltheaSession) auth() (manifests, error) {
 				"--silence-ping-logging",
 				"--alpha-config=/etc/oauth2-proxy/oauth2-proxy-alpha-config.yaml",
 				"--config=/etc/oauth2-proxy/oauth2-proxy-config.yaml",
+				fmt.Sprintf("--cookie-samesite=%s", sameSiteCookieFlag),
 			},
 			EnvFrom: []v1.EnvFromSource{
 				{

--- a/helm-chart/amalthea-sessions/templates/deployment.yaml
+++ b/helm-chart/amalthea-sessions/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
           value: {{ .Values.rcloneStorageClass | quote }}
         - name: SIDECARS_IMAGE
           value: {{ .Values.sidecars.image.repository }}:{{ .Values.sidecars.image.tag }}
+        - name: USE_NONE_SAME_SITE_SESSION_COOKIE
+          value: {{ .Values.useNoneSameSiteSessionCookie | quote }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
           | default .Chart.AppVersion }}
         livenessProbe:

--- a/helm-chart/amalthea-sessions/values.yaml
+++ b/helm-chart/amalthea-sessions/values.yaml
@@ -68,4 +68,7 @@ cloner:
     repository: renku/cloner
     tag: latest
 
+# Setting this flag to true will make the oauth2-proxy session cookie set its
+# SameSite parameter to None. This is only useful in specific cases for remote Renku cluster.
+# Setting this value to true can have security implications without adjusting CSP and CORS on the session ingress.
 useNoneSameSiteSessionCookie: false

--- a/helm-chart/amalthea-sessions/values.yaml
+++ b/helm-chart/amalthea-sessions/values.yaml
@@ -67,3 +67,5 @@ cloner:
   image:
     repository: renku/cloner
     tag: latest
+
+useNoneSameSiteSessionCookie: false


### PR DESCRIPTION
We can undo this in a followup release and handle it in the CRD. But we still cannot handle this nicely for remote clusters in the case of anonymous sessions.

/deploy extra-values=amalthea-sessions.useNoneSameSiteSessionCookie=true