### PR TITLE
feat: use self-minted tokens for sessions

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/internal/git-https-proxy/config/config.go
+++ b/internal/git-https-proxy/config/config.go
@@ -226,6 +226,5 @@ func (c *GitProxyConfig) validateRenkuAuthenticationV2() error {
 	if _, err := url.Parse(c.RenkuTokenURL); err != nil {
 		return fmt.Errorf("cannot parse renku token URL: %w", err)
 	}
-	return fmt.Errorf("not yet supported")
-	// return nil
+	return nil
 }

--- a/internal/git-https-proxy/config/config.go
+++ b/internal/git-https-proxy/config/config.go
@@ -28,6 +28,8 @@ type GitProxyConfig struct {
 	HealthPort int `mapstructure:"health_port"`
 	// True if this is an anonymous session
 	AnonymousSession bool `mapstructure:"anonymous_session"`
+	// The Renku authentication version, set to "v2" when using internal tokens
+	RenkuAuthenticationVersion string `mapstructure:"renku_authentication_version"`
 	// The oauth access token issued by Keycloak to a logged in Renku user
 	RenkuAccessToken string `mapstructure:"renku_access_token"`
 	// The oauth refresh token issued by Keycloak to a logged in Renku user
@@ -43,6 +45,8 @@ type GitProxyConfig struct {
 	RenkuClientID string `mapstructure:"renku_client_id"`
 	// The client secret for the client ID
 	RenkuClientSecret string `mapstructure:"renku_client_secret"`
+	// The URL used to refresh tokens (with "v2" authentication version)
+	RenkuTokenURL string `mapstructure:"renku_token_url"`
 	// The git repositories to proxy
 	Repositories []GitRepository `mapstructure:"repositories"`
 	// The git providers
@@ -60,12 +64,14 @@ func GetConfig() (GitProxyConfig, error) {
 	v.SetDefault("port", 8080)
 	v.SetDefault("health_port", 8081)
 	v.SetDefault("anonymous_session", true)
+	v.SetDefault("renku_authentication_version", "")
 	v.SetDefault("renku_access_token", "")
 	v.SetDefault("renku_refresh_token", "")
 	v.SetDefault("renku_url", nil)
 	v.SetDefault("renku_realm", "")
 	v.SetDefault("renku_client_id", "")
 	v.SetDefault("renku_client_secret", "")
+	v.SetDefault("renku_token_url", "")
 	v.SetDefault("repositories", []GitRepository{})
 	v.SetDefault("providers", []GitProvider{})
 	v.SetDefault("refresh_check_period_seconds", 600)
@@ -87,6 +93,10 @@ func (c *GitProxyConfig) Validate() error {
 	// INFO: The proxy is a pass-through for anonymous sessions, so no config is required.
 	if c.AnonymousSession {
 		return nil
+	}
+	// Validate "v2" authentication separately
+	if c.RenkuAuthenticationVersion == "v2" {
+		return c.validateRenkuAuthenticationV2()
 	}
 	if c.RenkuAccessToken == "" {
 		return fmt.Errorf("the renku access token is not defined")
@@ -203,4 +213,19 @@ func parseJsonVariable() mapstructure.DecodeHookFuncType {
 
 		return value.Interface(), nil
 	}
+}
+
+// validateRenkuAuthenticationV2 validates then config when "renku_authentication_version" is "v2"
+func (c *GitProxyConfig) validateRenkuAuthenticationV2() error {
+	if c.RenkuAccessToken == "" {
+		return fmt.Errorf("the renku access token is not defined")
+	}
+	if c.RenkuTokenURL == "" {
+		return fmt.Errorf("the renku token URL is not defined")
+	}
+	if _, err := url.Parse(c.RenkuTokenURL); err != nil {
+		return fmt.Errorf("cannot parse renku token URL: %w", err)
+	}
+	return fmt.Errorf("not yet supported")
+	// return nil
 }

--- a/internal/git-https-proxy/config/config.go
+++ b/internal/git-https-proxy/config/config.go
@@ -220,6 +220,9 @@ func (c *GitProxyConfig) validateRenkuAuthenticationV2() error {
 	if c.RenkuAccessToken == "" {
 		return fmt.Errorf("the renku access token is not defined")
 	}
+	if c.RenkuRefreshToken == "" {
+		return fmt.Errorf("the renku refresh token is not defined")
+	}
 	if c.RenkuTokenURL == "" {
 		return fmt.Errorf("the renku token URL is not defined")
 	}

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -69,6 +69,12 @@ func New(c *config.GitProxyConfig) *TokenStore {
 	if c.RenkuAuthenticationVersion == "v2" {
 		store.renkuRefreshToken = store.renkuAccessToken
 	}
+
+	// Debug
+	log.Printf("RenkuAuthenticationVersion = %s\n", store.Config.RenkuAuthenticationVersion)
+	log.Printf("RenkuTokenURL = %s\n", store.Config.RenkuTokenURL)
+	log.Printf("RefreshCheckPeriodSeconds = %d\n", store.Config.RefreshCheckPeriodSeconds)
+
 	// Start a go routine to keep the refresh token valid
 	go store.periodicTokenRefresh()
 	return &store
@@ -292,6 +298,8 @@ func (s *TokenStore) refreshRenkuAccessTokenV2() error {
 func (s *TokenStore) periodicTokenRefresh() {
 	for {
 		<-s.refreshTicker.C
+		// Debug
+		log.Println("tick periodicTokenRefresh()")
 		s.renkuAccessTokenLock.RLock()
 		renkuRefreshToken := s.renkuRefreshToken
 		s.renkuAccessTokenLock.RUnlock()

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -222,10 +222,6 @@ type renkuTokenRefreshResponse struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
-type renkuTokenRefreshV2Response struct {
-	AccessToken string `json:"access_token"`
-}
-
 // Refreshes the renku access token.
 func (s *TokenStore) refreshRenkuAccessToken() error {
 	if s.Config.RenkuAuthenticationVersion == "v2" {
@@ -267,15 +263,17 @@ func (s *TokenStore) refreshRenkuAccessTokenV2() error {
 	s.renkuAccessTokenLock.Lock()
 	defer s.renkuAccessTokenLock.Unlock()
 
-	url, err := url.Parse(s.Config.RenkuTokenURL)
+	renkuTokenURL, err := url.Parse(s.Config.RenkuTokenURL)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(http.MethodPost, url.String(), nil)
+	payload := url.Values{}
+	payload.Set("grant_type", "refresh_token")
+	payload.Set("refresh_token", s.renkuRefreshToken)
+	req, err := http.NewRequest(http.MethodPost, renkuTokenURL.String(), strings.NewReader((payload.Encode())))
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.renkuRefreshToken))
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
@@ -284,13 +282,13 @@ func (s *TokenStore) refreshRenkuAccessTokenV2() error {
 		err = fmt.Errorf("cannot refresh renku access token, failed with status code: %d", res.StatusCode)
 		return err
 	}
-	var resParsed renkuTokenRefreshV2Response
+	var resParsed renkuTokenRefreshResponse
 	err = json.NewDecoder(res.Body).Decode(&resParsed)
 	if err != nil {
 		return err
 	}
 	s.renkuAccessToken = resParsed.AccessToken
-	s.renkuRefreshToken = s.renkuAccessToken
+	s.renkuRefreshToken = resParsed.RefreshToken
 	return nil
 }
 

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -271,6 +271,7 @@ func (s *TokenStore) refreshRenkuAccessTokenV2() error {
 	payload.Set("grant_type", "refresh_token")
 	payload.Set("refresh_token", s.renkuRefreshToken)
 	req, err := http.NewRequest(http.MethodPost, renkuTokenURL.String(), strings.NewReader((payload.Encode())))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	if err != nil {
 		return err
 	}

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -267,7 +267,7 @@ func (s *TokenStore) refreshRenkuAccessTokenV2() error {
 	payload := url.Values{}
 	payload.Set("grant_type", "refresh_token")
 	payload.Set("refresh_token", s.renkuRefreshToken)
-	req, err := http.NewRequest(http.MethodPost, renkuTokenURL.String(), strings.NewReader((payload.Encode())))
+	req, err := http.NewRequest(http.MethodPost, renkuTokenURL.String(), strings.NewReader(payload.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	if err != nil {
 		return err

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -66,6 +66,9 @@ func New(c *config.GitProxyConfig) *TokenStore {
 		gitAccessTokens:      make(map[string]TokenSet, len(c.Providers)),
 		gitAccessTokensLock:  &sync.RWMutex{},
 	}
+	if c.RenkuAuthenticationVersion == "v2" {
+		store.renkuRefreshToken = store.renkuAccessToken
+	}
 	// Start a go routine to keep the refresh token valid
 	go store.periodicTokenRefresh()
 	return &store
@@ -213,8 +216,15 @@ type renkuTokenRefreshResponse struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
+type renkuTokenRefreshV2Response struct {
+	AccessToken string `json:"access_token"`
+}
+
 // Refreshes the renku access token.
 func (s *TokenStore) refreshRenkuAccessToken() error {
+	if s.Config.RenkuAuthenticationVersion == "v2" {
+		return s.refreshRenkuAccessTokenV2()
+	}
 	s.renkuAccessTokenLock.Lock()
 	defer s.renkuAccessTokenLock.Unlock()
 	payload := url.Values{}
@@ -244,6 +254,37 @@ func (s *TokenStore) refreshRenkuAccessToken() error {
 	if resParsed.RefreshToken != "" {
 		s.renkuRefreshToken = resParsed.RefreshToken
 	}
+	return nil
+}
+
+func (s *TokenStore) refreshRenkuAccessTokenV2() error {
+	s.renkuAccessTokenLock.Lock()
+	defer s.renkuAccessTokenLock.Unlock()
+
+	url, err := url.Parse(s.Config.RenkuTokenURL)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, url.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.renkuRefreshToken))
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		err = fmt.Errorf("cannot refresh renku access token, failed with status code: %d", res.StatusCode)
+		return err
+	}
+	var resParsed renkuTokenRefreshV2Response
+	err = json.NewDecoder(res.Body).Decode(&resParsed)
+	if err != nil {
+		return err
+	}
+	s.renkuAccessToken = resParsed.AccessToken
+	s.renkuRefreshToken = s.renkuAccessToken
 	return nil
 }
 

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -66,9 +66,6 @@ func New(c *config.GitProxyConfig) *TokenStore {
 		gitAccessTokens:      make(map[string]TokenSet, len(c.Providers)),
 		gitAccessTokensLock:  &sync.RWMutex{},
 	}
-	if c.RenkuAuthenticationVersion == "v2" {
-		store.renkuRefreshToken = store.renkuAccessToken
-	}
 
 	// Debug
 	log.Printf("RenkuAuthenticationVersion = %s\n", store.Config.RenkuAuthenticationVersion)

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -82,10 +82,11 @@ func New(c *config.GitProxyConfig) *TokenStore {
 func (s *TokenStore) GetGitAccessToken(provider string, encode bool) (string, error) {
 	s.gitAccessTokensLock.RLock()
 	tokenSet, accessTokenExists := s.gitAccessTokens[provider]
-	accessTokenExpiresAt := tokenSet.ExpiresAt
+	accessTokenExpiresAt := time.Unix(tokenSet.ExpiresAt, 0).UTC()
 	s.gitAccessTokensLock.RUnlock()
 
-	if !accessTokenExists || (0 < accessTokenExpiresAt && accessTokenExpiresAt < time.Now().Add(s.ExpirationLeeway).Unix()) {
+	// if !accessTokenExists || (0 < accessTokenExpiresAt && accessTokenExpiresAt < time.Now().Add(s.ExpirationLeeway).Unix()) {
+	if !accessTokenExists || !utils.IsNotExpired(accessTokenExpiresAt, s.ExpirationLeeway, false) {
 		log.Printf("Getting a fresh token for git provider: %s", provider)
 		if err := s.refreshGitAccessToken(provider); err != nil {
 			return "", err

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -67,11 +67,6 @@ func New(c *config.GitProxyConfig) *TokenStore {
 		gitAccessTokensLock:  &sync.RWMutex{},
 	}
 
-	// Debug
-	log.Printf("RenkuAuthenticationVersion = %s\n", store.Config.RenkuAuthenticationVersion)
-	log.Printf("RenkuTokenURL = %s\n", store.Config.RenkuTokenURL)
-	log.Printf("RefreshCheckPeriodSeconds = %d\n", store.Config.RefreshCheckPeriodSeconds)
-
 	// Start a go routine to keep the refresh token valid
 	go store.periodicTokenRefresh()
 	return &store
@@ -85,7 +80,6 @@ func (s *TokenStore) GetGitAccessToken(provider string, encode bool) (string, er
 	accessTokenExpiresAt := time.Unix(tokenSet.ExpiresAt, 0).UTC()
 	s.gitAccessTokensLock.RUnlock()
 
-	// if !accessTokenExists || (0 < accessTokenExpiresAt && accessTokenExpiresAt < time.Now().Add(s.ExpirationLeeway).Unix()) {
 	if !accessTokenExists || !utils.IsNotExpired(accessTokenExpiresAt, s.ExpirationLeeway, false) {
 		log.Printf("Getting a fresh token for git provider: %s", provider)
 		if err := s.refreshGitAccessToken(provider); err != nil {
@@ -155,7 +149,6 @@ func (s *TokenStore) refreshGitAccessToken(provider string) error {
 
 // Returns a valid renku access token. If the token is expired, the token will be refreshed first.
 func (s *TokenStore) getValidRenkuAccessToken() (string, error) {
-	// isExpired, err := s.isJWTExpired(s.getRenkuAccessToken())
 	isValid, err := utils.VerifyJWTExpiresAt(s.getRenkuAccessToken(), s.ExpirationLeeway, false)
 
 	if err != nil {
@@ -174,48 +167,6 @@ func (s *TokenStore) getRenkuAccessToken() string {
 	defer s.renkuAccessTokenLock.RUnlock()
 	return s.renkuAccessToken
 }
-
-// // VerifyExpiresAt implements the same logic as can be found in jwt v4 but
-// // in the style of v5.
-// //
-// // Main difference is that the exp nil check is hard coded to false.
-// //
-// // v4 implementation boils down to comparing the value passed to the expiration time.
-// // v5 changed that: "now" is compared to the expiration time with leeway added.
-// func VerifyExpiresAt(claims jwt.RegisteredClaims, leeway time.Duration) (bool, error) {
-// 	exp, err := claims.GetExpirationTime()
-// 	if err != nil {
-// 		return true, err
-// 	}
-
-// 	// Here we have it setup so that if the exp claim is not defined we assume the token is not expired.
-// 	// Keycloak does not set the `exp` claim on tokens that have the offline access grant - because they do not expire.
-// 	if exp == nil {
-// 		return false, nil
-// 	}
-
-// 	cmp := time.Now().Add(leeway)
-// 	return cmp.Before(exp.Time), nil
-// }
-
-// // Checks if the expiry of the token has passed or is coming up soon based on a predefined threshold.
-// // NOTE: no signature validation is performed at all. All of the tokens in the proxy are trusted implicitly
-// // because they come from trusted/controlled sources.
-// func (s *TokenStore) isJWTExpired(token string) (bool, error) {
-// 	parser := jwt.NewParser()
-// 	claims := jwt.RegisteredClaims{}
-// 	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
-// 		log.Printf("Cannot parse token claims, assuming token is expired: %s\n", err.Error())
-// 		return true, err
-// 	}
-
-// 	jwtIsNotExpired, err := VerifyExpiresAt(claims, s.ExpirationLeeway)
-// 	if err != nil {
-// 		return true, err
-// 	}
-
-// 	return !jwtIsNotExpired, err
-// }
 
 type renkuTokenRefreshResponse struct {
 	AccessToken  string `json:"access_token"`
@@ -297,12 +248,9 @@ func (s *TokenStore) refreshRenkuAccessTokenV2() error {
 func (s *TokenStore) periodicTokenRefresh() {
 	for {
 		<-s.refreshTicker.C
-		// Debug
-		log.Println("tick periodicTokenRefresh()")
 		s.renkuAccessTokenLock.RLock()
 		renkuRefreshToken := s.renkuRefreshToken
 		s.renkuAccessTokenLock.RUnlock()
-		// refreshTokenIsExpired, err := s.isJWTExpired(renkuRefreshToken)
 		refreshTokenIsValid, err := utils.VerifyJWTExpiresAt(renkuRefreshToken, s.ExpirationLeeway, false)
 		if err != nil {
 			log.Printf("Could not check if renku refresh token is expired: %s\n", err.Error())

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/SwissDataScienceCenter/amalthea/internal/git-https-proxy/config"
-	"github.com/golang-jwt/jwt/v5"
+	"github.com/SwissDataScienceCenter/amalthea/internal/utils"
 )
 
 type TokenSet struct {
@@ -154,11 +154,13 @@ func (s *TokenStore) refreshGitAccessToken(provider string) error {
 
 // Returns a valid renku access token. If the token is expired, the token will be refreshed first.
 func (s *TokenStore) getValidRenkuAccessToken() (string, error) {
-	isExpired, err := s.isJWTExpired(s.getRenkuAccessToken())
+	// isExpired, err := s.isJWTExpired(s.getRenkuAccessToken())
+	isValid, err := utils.VerifyJWTExpiresAt(s.getRenkuAccessToken(), s.ExpirationLeeway, false)
+
 	if err != nil {
 		return "", err
 	}
-	if isExpired {
+	if !isValid {
 		if err = s.refreshRenkuAccessToken(); err != nil {
 			return "", err
 		}
@@ -172,47 +174,47 @@ func (s *TokenStore) getRenkuAccessToken() string {
 	return s.renkuAccessToken
 }
 
-// VerifyExpiresAt implements the same logic as can be found in jwt v4 but
-// in the style of v5.
-//
-// Main difference is that the exp nil check is hard coded to false.
-//
-// v4 implementation boils down to comparing the value passed to the expiration time.
-// v5 changed that: "now" is compared to the expiration time with leeway added.
-func VerifyExpiresAt(claims jwt.RegisteredClaims, leeway time.Duration) (bool, error) {
-	exp, err := claims.GetExpirationTime()
-	if err != nil {
-		return true, err
-	}
+// // VerifyExpiresAt implements the same logic as can be found in jwt v4 but
+// // in the style of v5.
+// //
+// // Main difference is that the exp nil check is hard coded to false.
+// //
+// // v4 implementation boils down to comparing the value passed to the expiration time.
+// // v5 changed that: "now" is compared to the expiration time with leeway added.
+// func VerifyExpiresAt(claims jwt.RegisteredClaims, leeway time.Duration) (bool, error) {
+// 	exp, err := claims.GetExpirationTime()
+// 	if err != nil {
+// 		return true, err
+// 	}
 
-	// Here we have it setup so that if the exp claim is not defined we assume the token is not expired.
-	// Keycloak does not set the `exp` claim on tokens that have the offline access grant - because they do not expire.
-	if exp == nil {
-		return false, nil
-	}
+// 	// Here we have it setup so that if the exp claim is not defined we assume the token is not expired.
+// 	// Keycloak does not set the `exp` claim on tokens that have the offline access grant - because they do not expire.
+// 	if exp == nil {
+// 		return false, nil
+// 	}
 
-	cmp := time.Now().Add(leeway)
-	return cmp.Before(exp.Time), nil
-}
+// 	cmp := time.Now().Add(leeway)
+// 	return cmp.Before(exp.Time), nil
+// }
 
-// Checks if the expiry of the token has passed or is coming up soon based on a predefined threshold.
-// NOTE: no signature validation is performed at all. All of the tokens in the proxy are trusted implicitly
-// because they come from trusted/controlled sources.
-func (s *TokenStore) isJWTExpired(token string) (bool, error) {
-	parser := jwt.NewParser()
-	claims := jwt.RegisteredClaims{}
-	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
-		log.Printf("Cannot parse token claims, assuming token is expired: %s\n", err.Error())
-		return true, err
-	}
+// // Checks if the expiry of the token has passed or is coming up soon based on a predefined threshold.
+// // NOTE: no signature validation is performed at all. All of the tokens in the proxy are trusted implicitly
+// // because they come from trusted/controlled sources.
+// func (s *TokenStore) isJWTExpired(token string) (bool, error) {
+// 	parser := jwt.NewParser()
+// 	claims := jwt.RegisteredClaims{}
+// 	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
+// 		log.Printf("Cannot parse token claims, assuming token is expired: %s\n", err.Error())
+// 		return true, err
+// 	}
 
-	jwtIsNotExpired, err := VerifyExpiresAt(claims, s.ExpirationLeeway)
-	if err != nil {
-		return true, err
-	}
+// 	jwtIsNotExpired, err := VerifyExpiresAt(claims, s.ExpirationLeeway)
+// 	if err != nil {
+// 		return true, err
+// 	}
 
-	return !jwtIsNotExpired, err
-}
+// 	return !jwtIsNotExpired, err
+// }
 
 type renkuTokenRefreshResponse struct {
 	AccessToken  string `json:"access_token"`
@@ -299,11 +301,12 @@ func (s *TokenStore) periodicTokenRefresh() {
 		s.renkuAccessTokenLock.RLock()
 		renkuRefreshToken := s.renkuRefreshToken
 		s.renkuAccessTokenLock.RUnlock()
-		refreshTokenIsExpired, err := s.isJWTExpired(renkuRefreshToken)
+		// refreshTokenIsExpired, err := s.isJWTExpired(renkuRefreshToken)
+		refreshTokenIsValid, err := utils.VerifyJWTExpiresAt(renkuRefreshToken, s.ExpirationLeeway, false)
 		if err != nil {
 			log.Printf("Could not check if renku refresh token is expired: %s\n", err.Error())
 		}
-		if refreshTokenIsExpired {
+		if !refreshTokenIsValid {
 			log.Println("Getting a new renku refresh token from automatic checks")
 			err = s.refreshRenkuAccessToken()
 			if err != nil {

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -66,7 +66,6 @@ func New(c *config.GitProxyConfig) *TokenStore {
 		gitAccessTokens:      make(map[string]TokenSet, len(c.Providers)),
 		gitAccessTokensLock:  &sync.RWMutex{},
 	}
-
 	// Start a go routine to keep the refresh token valid
 	go store.periodicTokenRefresh()
 	return &store

--- a/internal/git-https-proxy/tokenstore/tokenstore.go
+++ b/internal/git-https-proxy/tokenstore/tokenstore.go
@@ -191,7 +191,7 @@ func VerifyExpiresAt(claims jwt.RegisteredClaims, leeway time.Duration) (bool, e
 		return false, nil
 	}
 
-	cmp := time.Now().Add(+leeway)
+	cmp := time.Now().Add(leeway)
 	return cmp.Before(exp.Time), nil
 }
 

--- a/internal/remote/config/config.go
+++ b/internal/remote/config/config.go
@@ -82,7 +82,12 @@ func SetFlags(cmd *cobra.Command) error {
 		return err
 	}
 
-	return runaiConfig.SetFlags(cmd)
+	// Set up RunAI flags
+	if err := runaiConfig.SetFlags(cmd); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func GetConfig() (cfg RemoteSessionControllerConfig, err error) {

--- a/internal/remote/config/firecrest/auth_config.go
+++ b/internal/remote/config/firecrest/auth_config.go
@@ -100,8 +100,8 @@ func (cfg *FirecrestAuthConfig) validateRenkuV2() error {
 	if _, err := url.Parse(cfg.TokenURI); err != nil {
 		return fmt.Errorf("tokenURI is not valid: %w", err)
 	}
-	if cfg.RenkuRefreshToken == "" {
-		return fmt.Errorf("renkuRefreshToken is not defined")
+	if cfg.RenkuAccessToken == "" {
+		return fmt.Errorf("renkuAccessToken is not defined")
 	}
 	if cfg.RenkuTokenURI == "" {
 		return fmt.Errorf("renkuTokenURI is not defined")

--- a/internal/remote/config/firecrest/auth_config.go
+++ b/internal/remote/config/firecrest/auth_config.go
@@ -60,7 +60,7 @@ func (cfg *FirecrestAuthConfig) Validate() error {
 		return cfg.validateRenku()
 	}
 	if cfg.Kind == FirecrestAuthConfigKindRenkuV2 {
-		return fmt.Errorf("not yet implemented")
+		return cfg.validateRenkuV2()
 	}
 	if cfg.Kind == FirecrestAuthConfigKindClientCredentials {
 		return cfg.validateClientCredentials()
@@ -89,6 +89,25 @@ func (cfg *FirecrestAuthConfig) validateRenku() error {
 	}
 	if cfg.RenkuClientSecret == "" {
 		return fmt.Errorf("renkuClientSecret is not defined")
+	}
+	return nil
+}
+
+func (cfg *FirecrestAuthConfig) validateRenkuV2() error {
+	if cfg.TokenURI == "" {
+		return fmt.Errorf("tokenURI is not defined")
+	}
+	if _, err := url.Parse(cfg.TokenURI); err != nil {
+		return fmt.Errorf("tokenURI is not valid: %w", err)
+	}
+	if cfg.RenkuRefreshToken == "" {
+		return fmt.Errorf("renkuRefreshToken is not defined")
+	}
+	if cfg.RenkuTokenURI == "" {
+		return fmt.Errorf("renkuTokenURI is not defined")
+	}
+	if _, err := url.Parse(cfg.RenkuTokenURI); err != nil {
+		return fmt.Errorf("renkuTokenURI is not valid: %w", err)
 	}
 	return nil
 }

--- a/internal/remote/config/firecrest/auth_config.go
+++ b/internal/remote/config/firecrest/auth_config.go
@@ -48,6 +48,7 @@ type FirecrestAuthConfig struct {
 type FirecrestAuthConfigKind string
 
 const FirecrestAuthConfigKindRenku = "renku"
+const FirecrestAuthConfigKindRenkuV2 = "renku_v2"
 const FirecrestAuthConfigKindClientCredentials = "client_credentials"
 
 // Validate checks that the authentication config is valid
@@ -57,6 +58,9 @@ func (cfg *FirecrestAuthConfig) Validate() error {
 	}
 	if cfg.Kind == FirecrestAuthConfigKindRenku {
 		return cfg.validateRenku()
+	}
+	if cfg.Kind == FirecrestAuthConfigKindRenkuV2 {
+		return fmt.Errorf("not yet implemented")
 	}
 	if cfg.Kind == FirecrestAuthConfigKindClientCredentials {
 		return cfg.validateClientCredentials()

--- a/internal/remote/config/firecrest/auth_config.go
+++ b/internal/remote/config/firecrest/auth_config.go
@@ -103,6 +103,9 @@ func (cfg *FirecrestAuthConfig) validateRenkuV2() error {
 	if cfg.RenkuAccessToken == "" {
 		return fmt.Errorf("renkuAccessToken is not defined")
 	}
+	if cfg.RenkuRefreshToken == "" {
+		return fmt.Errorf("renkuRefreshToken is not defined")
+	}
 	if cfg.RenkuTokenURI == "" {
 		return fmt.Errorf("renkuTokenURI is not defined")
 	}

--- a/internal/remote/firecrest/auth/auth.go
+++ b/internal/remote/firecrest/auth/auth.go
@@ -38,8 +38,25 @@ func NewFirecrestAuth(cfg firecrestConfig.FirecrestAuthConfig, options ...Firecr
 		}
 		return newRenkuAuth(
 			cfg.TokenURI,
+			"",
 			string(cfg.RenkuAccessToken),
 			string(cfg.RenkuRefreshToken),
+			cfg.RenkuTokenURI,
+			cfg.RenkuClientID,
+			string(cfg.RenkuClientSecret),
+			opts...,
+		)
+	}
+	if cfg.Kind == firecrestConfig.FirecrestAuthConfigKindRenkuV2 {
+		opts := make([]RenkuAuthOption, len(options))
+		for i := range options {
+			opts[i] = options[i].renkuAuthOption
+		}
+		return newRenkuAuth(
+			cfg.TokenURI,
+			"v2",
+			string(cfg.RenkuAccessToken),
+			string(cfg.RenkuAccessToken),
 			cfg.RenkuTokenURI,
 			cfg.RenkuClientID,
 			string(cfg.RenkuClientSecret),

--- a/internal/remote/firecrest/auth/auth.go
+++ b/internal/remote/firecrest/auth/auth.go
@@ -56,7 +56,7 @@ func NewFirecrestAuth(cfg firecrestConfig.FirecrestAuthConfig, options ...Firecr
 			cfg.TokenURI,
 			"v2",
 			string(cfg.RenkuAccessToken),
-			string(cfg.RenkuAccessToken),
+			string(cfg.RenkuRefreshToken),
 			cfg.RenkuTokenURI,
 			cfg.RenkuClientID,
 			string(cfg.RenkuClientSecret),

--- a/internal/remote/firecrest/auth/client_credentials.go
+++ b/internal/remote/firecrest/auth/client_credentials.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	sharedAuth "github.com/SwissDataScienceCenter/amalthea/internal/remote/auth/shared"
+	"github.com/SwissDataScienceCenter/amalthea/internal/utils"
 )
 
 // FirecrestClientCredentialsAuth implements the "Client Credentials Grant"
@@ -97,11 +98,12 @@ func (a *FirecrestClientCredentialsAuth) GetAccessToken(ctx context.Context) (to
 	expiresAt := a.accessTokenExpiresAt
 	a.accessTokenLock.RUnlock()
 
-	leeway := 10 * time.Second
-	deadline := time.Now().Add(leeway)
+	// leeway := 10 * time.Second
+	// deadline := time.Now().Add(leeway)
 
 	// Return the current token if it is still valid
-	if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
+	// if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
+	if token != "" && (utils.IsNotExpired(expiresAt, 10*time.Second, false)) {
 		return token, nil
 	}
 

--- a/internal/remote/firecrest/auth/client_credentials.go
+++ b/internal/remote/firecrest/auth/client_credentials.go
@@ -98,11 +98,7 @@ func (a *FirecrestClientCredentialsAuth) GetAccessToken(ctx context.Context) (to
 	expiresAt := a.accessTokenExpiresAt
 	a.accessTokenLock.RUnlock()
 
-	// leeway := 10 * time.Second
-	// deadline := time.Now().Add(leeway)
-
 	// Return the current token if it is still valid
-	// if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
 	if token != "" && (utils.IsNotExpired(expiresAt, 10*time.Second, false)) {
 		return token, nil
 	}

--- a/internal/remote/firecrest/auth/client_credentials.go
+++ b/internal/remote/firecrest/auth/client_credentials.go
@@ -98,10 +98,10 @@ func (a *FirecrestClientCredentialsAuth) GetAccessToken(ctx context.Context) (to
 	a.accessTokenLock.RUnlock()
 
 	leeway := 10 * time.Second
-	deadline := time.Now().Add(-leeway)
+	deadline := time.Now().Add(leeway)
 
 	// Return the current token if it is still valid
-	if token != "" && (expiresAt.IsZero() || expiresAt.Before(deadline)) {
+	if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
 		return token, nil
 	}
 

--- a/internal/remote/firecrest/auth/renku.go
+++ b/internal/remote/firecrest/auth/renku.go
@@ -18,12 +18,16 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
 	sharedAuth "github.com/SwissDataScienceCenter/amalthea/internal/remote/auth/shared"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // RenkuAuth implements authentication as used in Renku:
@@ -35,6 +39,8 @@ type RenkuAuth struct {
 	// firecrestTokenURI the URI used to request new access tokens
 	firecrestTokenURI string
 
+	// renkuAuthenticationVersion is equal to "v2" when using internal tokens
+	renkuAuthenticationVersion string
 	// renkuAccessToken the current renku access token
 	renkuAccessToken string
 	// renkuAccessTokenExpiresAt is when the renku access token expires
@@ -57,6 +63,8 @@ type RenkuAuth struct {
 	// accessTokenLock ensures that we do not try to refresh
 	// the accessToken twice at the same time.
 	accessTokenLock *sync.RWMutex
+	// refreshTicker to automate renku access token refresh
+	refreshTicker *time.Ticker
 
 	// httpClient is the HTTP client used to obtain access tokens
 	httpClient *http.Client
@@ -65,19 +73,20 @@ type RenkuAuth struct {
 // Check that RenkuAuth satisfies the FirecrestAuth interface
 var _ FirecrestAuth = (*RenkuAuth)(nil)
 
-func newRenkuAuth(firecrestTokenURI, renkuAccessToken, renkuRefreshToken, renkuTokenURI, renkuClientID, renkuClientSecret string, options ...RenkuAuthOption) (auth *RenkuAuth, err error) {
+func newRenkuAuth(firecrestTokenURI, renkuAuthenticationVersion, renkuAccessToken, renkuRefreshToken, renkuTokenURI, renkuClientID, renkuClientSecret string, options ...RenkuAuthOption) (auth *RenkuAuth, err error) {
 	auth = &RenkuAuth{
-		firecrestTokenURI:         firecrestTokenURI,
-		renkuAccessToken:          renkuAccessToken,
-		renkuAccessTokenExpiresAt: time.Time{},
-		renkuRefreshToken:         renkuRefreshToken,
-		renkuTokenURI:             renkuTokenURI,
-		renkuClientID:             renkuClientID,
-		renkuClientSecret:         renkuClientSecret,
-		renkuAccessTokenLock:      &sync.RWMutex{},
-		accessToken:               "",
-		accessTokenExpiresAt:      time.Time{},
-		accessTokenLock:           &sync.RWMutex{},
+		firecrestTokenURI:          firecrestTokenURI,
+		renkuAuthenticationVersion: renkuAuthenticationVersion,
+		renkuAccessToken:           renkuAccessToken,
+		renkuAccessTokenExpiresAt:  time.Time{},
+		renkuRefreshToken:          renkuRefreshToken,
+		renkuTokenURI:              renkuTokenURI,
+		renkuClientID:              renkuClientID,
+		renkuClientSecret:          renkuClientSecret,
+		renkuAccessTokenLock:       &sync.RWMutex{},
+		accessToken:                "",
+		accessTokenExpiresAt:       time.Time{},
+		accessTokenLock:            &sync.RWMutex{},
 	}
 	for _, opt := range options {
 		if err := opt(auth); err != nil {
@@ -104,6 +113,11 @@ func newRenkuAuth(firecrestTokenURI, renkuAccessToken, renkuRefreshToken, renkuT
 	if auth.httpClient == nil {
 		auth.httpClient = http.DefaultClient
 	}
+
+	auth.refreshTicker = time.NewTicker(time.Duration(60) * time.Second)
+	// Start a go routine to keep the refresh token valid
+	go auth.periodicTokenRefresh()
+
 	return auth, nil
 }
 
@@ -213,6 +227,10 @@ func (a *RenkuAuth) getRenkuAccessToken(ctx context.Context) (token string, err 
 }
 
 func (a *RenkuAuth) refreshRenkuAccessToken(ctx context.Context) error {
+	if a.renkuAuthenticationVersion == "v2" {
+		return a.refreshRenkuAccessTokenV2(ctx)
+	}
+
 	a.renkuAccessTokenLock.Lock()
 	defer a.renkuAccessTokenLock.Unlock()
 
@@ -228,4 +246,106 @@ func (a *RenkuAuth) refreshRenkuAccessToken(ctx context.Context) error {
 	a.renkuAccessToken = result.AccessToken
 	a.renkuAccessTokenExpiresAt = result.ExpiresAt
 	return nil
+}
+
+func (a *RenkuAuth) refreshRenkuAccessTokenV2(ctx context.Context) error {
+	a.renkuAccessTokenLock.Lock()
+	defer a.renkuAccessTokenLock.Unlock()
+
+	url, err := url.Parse(a.renkuTokenURI)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", a.renkuRefreshToken))
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		err = fmt.Errorf("cannot refresh renku access token, failed with status code: %d", res.StatusCode)
+		return err
+	}
+	var resParsed renkuTokenRefreshV2Response
+	err = json.NewDecoder(res.Body).Decode(&resParsed)
+	if err != nil {
+		return err
+	}
+	a.renkuAccessToken = resParsed.AccessToken
+	a.renkuRefreshToken = a.renkuAccessToken
+	return nil
+}
+
+type renkuTokenRefreshV2Response struct {
+	AccessToken string `json:"access_token"`
+}
+
+// Periodically refreshes the renku access token. Used to make sure the refresh token does not expire.
+func (a *RenkuAuth) periodicTokenRefresh() {
+	for {
+		<-a.refreshTicker.C
+		// Debug
+		log.Println("tick periodicTokenRefresh()")
+		a.renkuAccessTokenLock.RLock()
+		renkuRefreshToken := a.renkuRefreshToken
+		a.renkuAccessTokenLock.RUnlock()
+		refreshTokenIsExpired, err := a.isJWTExpired(renkuRefreshToken)
+		if err != nil {
+			log.Printf("Could not check if renku refresh token is expired: %s\n", err.Error())
+		}
+		if refreshTokenIsExpired {
+			log.Println("Getting a new renku refresh token from automatic checks")
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(60)*time.Second)
+			err = a.refreshRenkuAccessToken(ctx)
+			cancel()
+			if err != nil {
+				log.Printf("Could not refresh renku token: %s\n", err.Error())
+			}
+		}
+	}
+}
+
+// Checks if the expiry of the token has passed or is coming up soon based on a predefined threshold.
+// NOTE: no signature validation is performed at all. All of the tokens in the proxy are trusted implicitly
+// because they come from trusted/controlled sources.
+func (a *RenkuAuth) isJWTExpired(token string) (bool, error) {
+	parser := jwt.NewParser()
+	claims := jwt.RegisteredClaims{}
+	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
+		log.Printf("Cannot parse token claims, assuming token is expired: %s\n", err.Error())
+		return true, err
+	}
+
+	jwtIsNotExpired, err := verifyExpiresAt(claims, time.Duration(4*60)*time.Second)
+	if err != nil {
+		return true, err
+	}
+
+	return !jwtIsNotExpired, err
+}
+
+// VerifyExpiresAt implements the same logic as can be found in jwt v4 but
+// in the style of v5.
+//
+// Main difference is that the exp nil check is hard coded to false.
+//
+// v4 implementation boils down to comparing the value passed to the expiration time.
+// v5 changed that: "now" is compared to the expiration time with leeway added.
+func verifyExpiresAt(claims jwt.RegisteredClaims, leeway time.Duration) (bool, error) {
+	exp, err := claims.GetExpirationTime()
+	if err != nil {
+		return true, err
+	}
+
+	// Here we have it setup so that if the exp claim is not defined we assume the token is not expired.
+	// Keycloak does not set the `exp` claim on tokens that have the offline access grant - because they do not expire.
+	if exp == nil {
+		return false, nil
+	}
+
+	cmp := time.Now().Add(+leeway)
+	return cmp.Before(exp.Time), nil
 }

--- a/internal/remote/firecrest/auth/renku.go
+++ b/internal/remote/firecrest/auth/renku.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -252,15 +253,18 @@ func (a *RenkuAuth) refreshRenkuAccessTokenV2(ctx context.Context) error {
 	a.renkuAccessTokenLock.Lock()
 	defer a.renkuAccessTokenLock.Unlock()
 
-	url, err := url.Parse(a.renkuTokenURI)
+	renkuTokenURL, err := url.Parse(a.renkuTokenURI)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), nil)
+	payload := url.Values{}
+	payload.Set("grant_type", "refresh_token")
+	payload.Set("refresh_token", a.renkuRefreshToken)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, renkuTokenURL.String(), strings.NewReader(payload.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", a.renkuRefreshToken))
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
@@ -269,18 +273,19 @@ func (a *RenkuAuth) refreshRenkuAccessTokenV2(ctx context.Context) error {
 		err = fmt.Errorf("cannot refresh renku access token, failed with status code: %d", res.StatusCode)
 		return err
 	}
-	var resParsed renkuTokenRefreshV2Response
+	var resParsed renkuTokenRefreshResponse
 	err = json.NewDecoder(res.Body).Decode(&resParsed)
 	if err != nil {
 		return err
 	}
 	a.renkuAccessToken = resParsed.AccessToken
-	a.renkuRefreshToken = a.renkuAccessToken
+	a.renkuRefreshToken = resParsed.RefreshToken
 	return nil
 }
 
-type renkuTokenRefreshV2Response struct {
-	AccessToken string `json:"access_token"`
+type renkuTokenRefreshResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
 }
 
 // Periodically refreshes the renku access token. Used to make sure the refresh token does not expire.

--- a/internal/remote/firecrest/auth/renku.go
+++ b/internal/remote/firecrest/auth/renku.go
@@ -280,6 +280,15 @@ func (a *RenkuAuth) refreshRenkuAccessTokenV2(ctx context.Context) error {
 	}
 	a.renkuAccessToken = resParsed.AccessToken
 	a.renkuRefreshToken = resParsed.RefreshToken
+
+	parser := jwt.NewParser()
+	claims := jwt.RegisteredClaims{}
+	if _, _, err := parser.ParseUnverified(a.renkuAccessToken, &claims); err != nil {
+		log.Printf("cannot parse token claims: %s\n", err.Error())
+		return err
+	}
+	a.renkuAccessTokenExpiresAt = claims.ExpiresAt.Time
+
 	return nil
 }
 

--- a/internal/remote/firecrest/auth/renku.go
+++ b/internal/remote/firecrest/auth/renku.go
@@ -103,10 +103,10 @@ func newRenkuAuth(firecrestTokenURI, renkuAuthenticationVersion, renkuAccessToke
 	if renkuTokenURI == "" {
 		return nil, fmt.Errorf("renkuTokenURI is not set")
 	}
-	if renkuClientID == "" {
+	if renkuAuthenticationVersion != "v2" && renkuClientID == "" {
 		return nil, fmt.Errorf("renkuClientID is not set")
 	}
-	if renkuClientSecret == "" {
+	if renkuAuthenticationVersion != "v2" && renkuClientSecret == "" {
 		return nil, fmt.Errorf("renkuClientSecret is not set")
 	}
 	// Create httpClient, if not already present

--- a/internal/remote/firecrest/auth/renku.go
+++ b/internal/remote/firecrest/auth/renku.go
@@ -223,7 +223,10 @@ func (a *RenkuAuth) getRenkuAccessToken(ctx context.Context) (token string, err 
 
 	// Return the current token if it is still valid
 	if token != "" && (expiresAt.IsZero() || expiresAt.Before(deadline)) {
+		log.Printf("renku access token valid\n")
 		return token, nil
+	} else {
+		log.Printf("renku access token expired\n")
 	}
 
 	// Refresh the token
@@ -296,6 +299,8 @@ func (a *RenkuAuth) refreshRenkuAccessTokenV2(ctx context.Context) error {
 		return err
 	}
 	a.renkuAccessTokenExpiresAt = claims.ExpiresAt.Time
+
+	log.Printf("refreshed renku access tokens, renkuAccessTokenExpiresAt = %s\n", a.renkuAccessTokenExpiresAt.String())
 
 	return nil
 }

--- a/internal/remote/firecrest/auth/renku.go
+++ b/internal/remote/firecrest/auth/renku.go
@@ -220,16 +220,9 @@ func (a *RenkuAuth) getRenkuAccessToken(ctx context.Context) (token string, err 
 	expiresAt := a.renkuAccessTokenExpiresAt
 	a.renkuAccessTokenLock.RUnlock()
 
-	// leeway := 10 * time.Second
-	// deadline := time.Now().Add(-leeway)
-
 	// Return the current token if it is still valid
-	// if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
 	if token != "" && (utils.IsNotExpired(expiresAt, 10*time.Second, false)) {
-		log.Printf("renku access token valid, expiresAt = %s\n", expiresAt.String())
 		return token, nil
-	} else {
-		log.Printf("renku access token expired, expiresAt = %s\n", expiresAt.String())
 	}
 
 	// Refresh the token
@@ -317,12 +310,9 @@ type renkuTokenRefreshResponse struct {
 func (a *RenkuAuth) periodicTokenRefresh() {
 	for {
 		<-a.refreshTicker.C
-		// Debug
-		log.Println("tick periodicTokenRefresh()")
 		a.renkuAccessTokenLock.RLock()
 		renkuRefreshToken := a.renkuRefreshToken
 		a.renkuAccessTokenLock.RUnlock()
-		// refreshTokenIsExpired, err := a.isJWTExpired(renkuRefreshToken)
 		refreshTokenIsValid, err := utils.VerifyJWTExpiresAt(renkuRefreshToken, 4*time.Minute, false)
 		if err != nil {
 			log.Printf("Could not check if renku refresh token is expired: %s\n", err.Error())
@@ -338,45 +328,3 @@ func (a *RenkuAuth) periodicTokenRefresh() {
 		}
 	}
 }
-
-// // Checks if the expiry of the token has passed or is coming up soon based on a predefined threshold.
-// // NOTE: no signature validation is performed at all. All of the tokens in the proxy are trusted implicitly
-// // because they come from trusted/controlled sources.
-// func (a *RenkuAuth) isJWTExpired(token string) (bool, error) {
-// 	parser := jwt.NewParser()
-// 	claims := jwt.RegisteredClaims{}
-// 	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
-// 		log.Printf("Cannot parse token claims, assuming token is expired: %s\n", err.Error())
-// 		return true, err
-// 	}
-
-// 	jwtIsNotExpired, err := verifyExpiresAt(claims, time.Duration(4*60)*time.Second)
-// 	if err != nil {
-// 		return true, err
-// 	}
-
-// 	return !jwtIsNotExpired, err
-// }
-
-// // VerifyExpiresAt implements the same logic as can be found in jwt v4 but
-// // in the style of v5.
-// //
-// // Main difference is that the exp nil check is hard coded to false.
-// //
-// // v4 implementation boils down to comparing the value passed to the expiration time.
-// // v5 changed that: "now" is compared to the expiration time with leeway added.
-// func verifyExpiresAt(claims jwt.RegisteredClaims, leeway time.Duration) (bool, error) {
-// 	exp, err := claims.GetExpirationTime()
-// 	if err != nil {
-// 		return true, err
-// 	}
-
-// 	// Here we have it setup so that if the exp claim is not defined we assume the token is not expired.
-// 	// Keycloak does not set the `exp` claim on tokens that have the offline access grant - because they do not expire.
-// 	if exp == nil {
-// 		return false, nil
-// 	}
-
-// 	cmp := time.Now().Add(leeway)
-// 	return cmp.Before(exp.Time), nil
-// }

--- a/internal/remote/firecrest/auth/renku.go
+++ b/internal/remote/firecrest/auth/renku.go
@@ -149,7 +149,7 @@ func (a *RenkuAuth) GetAccessToken(ctx context.Context) (token string, err error
 	deadline := time.Now().Add(-leeway)
 
 	// Return the current token if it is still valid
-	if token != "" && (expiresAt.IsZero() || expiresAt.Before(deadline)) {
+	if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
 		return token, nil
 	}
 
@@ -222,11 +222,11 @@ func (a *RenkuAuth) getRenkuAccessToken(ctx context.Context) (token string, err 
 	deadline := time.Now().Add(-leeway)
 
 	// Return the current token if it is still valid
-	if token != "" && (expiresAt.IsZero() || expiresAt.Before(deadline)) {
+	if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
 		log.Printf("renku access token valid\n")
 		return token, nil
 	} else {
-		log.Printf("renku access token expired\n")
+		log.Printf("renku access token expired, expiresAt = %s, deadline = %s\n", expiresAt.String(), deadline.String())
 	}
 
 	// Refresh the token
@@ -373,6 +373,6 @@ func verifyExpiresAt(claims jwt.RegisteredClaims, leeway time.Duration) (bool, e
 		return false, nil
 	}
 
-	cmp := time.Now().Add(+leeway)
+	cmp := time.Now().Add(leeway)
 	return cmp.Before(exp.Time), nil
 }

--- a/internal/remote/firecrest/auth/renku.go
+++ b/internal/remote/firecrest/auth/renku.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	sharedAuth "github.com/SwissDataScienceCenter/amalthea/internal/remote/auth/shared"
+	"github.com/SwissDataScienceCenter/amalthea/internal/utils"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -145,11 +146,12 @@ func (a *RenkuAuth) GetAccessToken(ctx context.Context) (token string, err error
 	expiresAt := a.accessTokenExpiresAt
 	a.accessTokenLock.RUnlock()
 
-	leeway := 10 * time.Second
-	deadline := time.Now().Add(-leeway)
+	// leeway := 10 * time.Second
+	// deadline := time.Now().Add(-leeway)
 
 	// Return the current token if it is still valid
-	if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
+	// if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
+	if token != "" && (utils.IsNotExpired(expiresAt, 10*time.Second, false)) {
 		return token, nil
 	}
 
@@ -218,15 +220,16 @@ func (a *RenkuAuth) getRenkuAccessToken(ctx context.Context) (token string, err 
 	expiresAt := a.renkuAccessTokenExpiresAt
 	a.renkuAccessTokenLock.RUnlock()
 
-	leeway := 10 * time.Second
-	deadline := time.Now().Add(-leeway)
+	// leeway := 10 * time.Second
+	// deadline := time.Now().Add(-leeway)
 
 	// Return the current token if it is still valid
-	if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
-		log.Printf("renku access token valid\n")
+	// if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
+	if token != "" && (utils.IsNotExpired(expiresAt, 10*time.Second, false)) {
+		log.Printf("renku access token valid, expiresAt = %s\n", expiresAt.String())
 		return token, nil
 	} else {
-		log.Printf("renku access token expired, expiresAt = %s, deadline = %s\n", expiresAt.String(), deadline.String())
+		log.Printf("renku access token expired, expiresAt = %s\n", expiresAt.String())
 	}
 
 	// Refresh the token
@@ -319,11 +322,12 @@ func (a *RenkuAuth) periodicTokenRefresh() {
 		a.renkuAccessTokenLock.RLock()
 		renkuRefreshToken := a.renkuRefreshToken
 		a.renkuAccessTokenLock.RUnlock()
-		refreshTokenIsExpired, err := a.isJWTExpired(renkuRefreshToken)
+		// refreshTokenIsExpired, err := a.isJWTExpired(renkuRefreshToken)
+		refreshTokenIsValid, err := utils.VerifyJWTExpiresAt(renkuRefreshToken, 4*time.Minute, false)
 		if err != nil {
 			log.Printf("Could not check if renku refresh token is expired: %s\n", err.Error())
 		}
-		if refreshTokenIsExpired {
+		if !refreshTokenIsValid {
 			log.Println("Getting a new renku refresh token from automatic checks")
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(60)*time.Second)
 			err = a.refreshRenkuAccessToken(ctx)
@@ -335,44 +339,44 @@ func (a *RenkuAuth) periodicTokenRefresh() {
 	}
 }
 
-// Checks if the expiry of the token has passed or is coming up soon based on a predefined threshold.
-// NOTE: no signature validation is performed at all. All of the tokens in the proxy are trusted implicitly
-// because they come from trusted/controlled sources.
-func (a *RenkuAuth) isJWTExpired(token string) (bool, error) {
-	parser := jwt.NewParser()
-	claims := jwt.RegisteredClaims{}
-	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
-		log.Printf("Cannot parse token claims, assuming token is expired: %s\n", err.Error())
-		return true, err
-	}
+// // Checks if the expiry of the token has passed or is coming up soon based on a predefined threshold.
+// // NOTE: no signature validation is performed at all. All of the tokens in the proxy are trusted implicitly
+// // because they come from trusted/controlled sources.
+// func (a *RenkuAuth) isJWTExpired(token string) (bool, error) {
+// 	parser := jwt.NewParser()
+// 	claims := jwt.RegisteredClaims{}
+// 	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
+// 		log.Printf("Cannot parse token claims, assuming token is expired: %s\n", err.Error())
+// 		return true, err
+// 	}
 
-	jwtIsNotExpired, err := verifyExpiresAt(claims, time.Duration(4*60)*time.Second)
-	if err != nil {
-		return true, err
-	}
+// 	jwtIsNotExpired, err := verifyExpiresAt(claims, time.Duration(4*60)*time.Second)
+// 	if err != nil {
+// 		return true, err
+// 	}
 
-	return !jwtIsNotExpired, err
-}
+// 	return !jwtIsNotExpired, err
+// }
 
-// VerifyExpiresAt implements the same logic as can be found in jwt v4 but
-// in the style of v5.
-//
-// Main difference is that the exp nil check is hard coded to false.
-//
-// v4 implementation boils down to comparing the value passed to the expiration time.
-// v5 changed that: "now" is compared to the expiration time with leeway added.
-func verifyExpiresAt(claims jwt.RegisteredClaims, leeway time.Duration) (bool, error) {
-	exp, err := claims.GetExpirationTime()
-	if err != nil {
-		return true, err
-	}
+// // VerifyExpiresAt implements the same logic as can be found in jwt v4 but
+// // in the style of v5.
+// //
+// // Main difference is that the exp nil check is hard coded to false.
+// //
+// // v4 implementation boils down to comparing the value passed to the expiration time.
+// // v5 changed that: "now" is compared to the expiration time with leeway added.
+// func verifyExpiresAt(claims jwt.RegisteredClaims, leeway time.Duration) (bool, error) {
+// 	exp, err := claims.GetExpirationTime()
+// 	if err != nil {
+// 		return true, err
+// 	}
 
-	// Here we have it setup so that if the exp claim is not defined we assume the token is not expired.
-	// Keycloak does not set the `exp` claim on tokens that have the offline access grant - because they do not expire.
-	if exp == nil {
-		return false, nil
-	}
+// 	// Here we have it setup so that if the exp claim is not defined we assume the token is not expired.
+// 	// Keycloak does not set the `exp` claim on tokens that have the offline access grant - because they do not expire.
+// 	if exp == nil {
+// 		return false, nil
+// 	}
 
-	cmp := time.Now().Add(leeway)
-	return cmp.Before(exp.Time), nil
-}
+// 	cmp := time.Now().Add(leeway)
+// 	return cmp.Before(exp.Time), nil
+// }

--- a/internal/remote/firecrest/auth/renku.go
+++ b/internal/remote/firecrest/auth/renku.go
@@ -146,11 +146,7 @@ func (a *RenkuAuth) GetAccessToken(ctx context.Context) (token string, err error
 	expiresAt := a.accessTokenExpiresAt
 	a.accessTokenLock.RUnlock()
 
-	// leeway := 10 * time.Second
-	// deadline := time.Now().Add(-leeway)
-
 	// Return the current token if it is still valid
-	// if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
 	if token != "" && (utils.IsNotExpired(expiresAt, 10*time.Second, false)) {
 		return token, nil
 	}

--- a/internal/remote/firecrest/auth/renku.go
+++ b/internal/remote/firecrest/auth/renku.go
@@ -110,6 +110,14 @@ func newRenkuAuth(firecrestTokenURI, renkuAuthenticationVersion, renkuAccessToke
 	if renkuAuthenticationVersion != "v2" && renkuClientSecret == "" {
 		return nil, fmt.Errorf("renkuClientSecret is not set")
 	}
+	if renkuAuthenticationVersion == "v2" {
+		parser := jwt.NewParser()
+		claims := jwt.RegisteredClaims{}
+		_, _, err := parser.ParseUnverified(auth.renkuAccessToken, &claims)
+		if err == nil {
+			auth.renkuAccessTokenExpiresAt = claims.ExpiresAt.Time
+		}
+	}
 	// Create httpClient, if not already present
 	if auth.httpClient == nil {
 		auth.httpClient = http.DefaultClient

--- a/internal/remote/runai/auth/client_credentials.go
+++ b/internal/remote/runai/auth/client_credentials.go
@@ -100,11 +100,7 @@ func (a *RunaiClientCredentialsAuth) GetAccessToken(ctx context.Context) (token 
 	expiresAt := a.accessTokenExpiresAt
 	a.accessTokenLock.RUnlock()
 
-	// leeway := 10 * time.Second
-	// deadline := time.Now().Add(-leeway)
-
 	// Return the current token if it is still valid
-	// if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
 	if token != "" && (utils.IsNotExpired(expiresAt, 10*time.Second, false)) {
 		return token, nil
 	}
@@ -124,11 +120,8 @@ func (a *RunaiClientCredentialsAuth) refreshAccessToken(ctx context.Context) (to
 	// Re-check if another goroutine has already refreshed the token
 	token = a.accessToken
 	expiresAt := a.accessTokenExpiresAt
-	// leeway := 10 * time.Second
-	// deadline := time.Now().Add(-leeway)
 
 	// Return the current token if it is still valid
-	// if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
 	if token != "" && (utils.IsNotExpired(expiresAt, 10*time.Second, false)) {
 		return token, nil
 	}

--- a/internal/remote/runai/auth/client_credentials.go
+++ b/internal/remote/runai/auth/client_credentials.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	sharedAuth "github.com/SwissDataScienceCenter/amalthea/internal/remote/auth/shared"
+	"github.com/SwissDataScienceCenter/amalthea/internal/utils"
 )
 
 // RunaiClientCredentialsAuth implements the "Client Credentials Grant"
@@ -99,11 +100,12 @@ func (a *RunaiClientCredentialsAuth) GetAccessToken(ctx context.Context) (token 
 	expiresAt := a.accessTokenExpiresAt
 	a.accessTokenLock.RUnlock()
 
-	leeway := 10 * time.Second
-	deadline := time.Now().Add(-leeway)
+	// leeway := 10 * time.Second
+	// deadline := time.Now().Add(-leeway)
 
 	// Return the current token if it is still valid
-	if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
+	// if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
+	if token != "" && (utils.IsNotExpired(expiresAt, 10*time.Second, false)) {
 		return token, nil
 	}
 
@@ -122,11 +124,12 @@ func (a *RunaiClientCredentialsAuth) refreshAccessToken(ctx context.Context) (to
 	// Re-check if another goroutine has already refreshed the token
 	token = a.accessToken
 	expiresAt := a.accessTokenExpiresAt
-	leeway := 10 * time.Second
-	deadline := time.Now().Add(-leeway)
+	// leeway := 10 * time.Second
+	// deadline := time.Now().Add(-leeway)
 
 	// Return the current token if it is still valid
-	if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
+	// if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
+	if token != "" && (utils.IsNotExpired(expiresAt, 10*time.Second, false)) {
 		return token, nil
 	}
 

--- a/internal/remote/runai/auth/client_credentials.go
+++ b/internal/remote/runai/auth/client_credentials.go
@@ -103,7 +103,7 @@ func (a *RunaiClientCredentialsAuth) GetAccessToken(ctx context.Context) (token 
 	deadline := time.Now().Add(-leeway)
 
 	// Return the current token if it is still valid
-	if token != "" && (expiresAt.IsZero() || expiresAt.Before(deadline)) {
+	if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
 		return token, nil
 	}
 
@@ -126,7 +126,7 @@ func (a *RunaiClientCredentialsAuth) refreshAccessToken(ctx context.Context) (to
 	deadline := time.Now().Add(-leeway)
 
 	// Return the current token if it is still valid
-	if token != "" && (expiresAt.IsZero() || expiresAt.Before(deadline)) {
+	if token != "" && (expiresAt.IsZero() || expiresAt.After(deadline)) {
 		return token, nil
 	}
 

--- a/internal/utils/token.go
+++ b/internal/utils/token.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// IsNotExpired returns true if expiresAt is still in the future, with a given margin.
+// When expiresAt is zero, returns !required.
+func IsNotExpired(expiresAt time.Time, margin time.Duration, required bool) bool {
+	now := time.Now()
+	deadline := now.Add(-margin)
+
+	result := false
+	if expiresAt.IsZero() {
+		result = !required
+	} else {
+		result = expiresAt.After(deadline)
+	}
+
+	slog.Info("IsNotExpired", "result", result, "expiresAt", expiresAt.String(), "now", now.String(), "margin", margin.String(), "deadline", deadline.String(), "required", required)
+
+	return result
+}
+
+// VerifyExpiresAtClaim returns true is the expiry (claims.GetExpirationTime()) is still in the future, with a given margin.
+// When the expiry is omitted, returns !required.
+func VerifyExpiresAtClaim(claims jwt.RegisteredClaims, margin time.Duration, required bool) (bool, error) {
+	expiresAt, err := claims.GetExpirationTime()
+	if err != nil {
+		return false, err
+	}
+	if expiresAt == nil {
+		return !required, nil
+	}
+	return IsNotExpired(expiresAt.Time, margin, required), nil
+}
+
+// VerifyJWTExpiresAt returns true is the expiry (from the "exp" claim) is still in the future, with a given margin.
+// When the expiry is omitted, returns !required.
+func VerifyJWTExpiresAt(token string, margin time.Duration, required bool) (bool, error) {
+	parser := jwt.NewParser()
+	claims := jwt.RegisteredClaims{}
+	if _, _, err := parser.ParseUnverified(token, &claims); err != nil {
+		slog.Error("Cannot parse token claims, assuming token is expired", "error", err)
+		return false, err
+	}
+	return VerifyExpiresAtClaim(claims, margin, required)
+}

--- a/internal/utils/token.go
+++ b/internal/utils/token.go
@@ -12,17 +12,10 @@ import (
 func IsNotExpired(expiresAt time.Time, margin time.Duration, required bool) bool {
 	now := time.Now()
 	deadline := now.Add(margin)
-
-	result := false
 	if expiresAt.IsZero() {
-		result = !required
-	} else {
-		result = expiresAt.After(deadline)
+		return !required
 	}
-
-	slog.Info("IsNotExpired", "result", result, "expiresAt", expiresAt.String(), "now", now.String(), "margin", margin.String(), "deadline", deadline.String(), "required", required)
-
-	return result
+	return deadline.Before(expiresAt)
 }
 
 // VerifyExpiresAtClaim returns true is the expiry (claims.GetExpirationTime()) is still in the future, with a given margin.

--- a/internal/utils/token.go
+++ b/internal/utils/token.go
@@ -11,7 +11,7 @@ import (
 // When expiresAt is zero, returns !required.
 func IsNotExpired(expiresAt time.Time, margin time.Duration, required bool) bool {
 	now := time.Now()
-	deadline := now.Add(-margin)
+	deadline := now.Add(margin)
 
 	result := false
 	if expiresAt.IsZero() {

--- a/internal/utils/token_test.go
+++ b/internal/utils/token_test.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNotExpired(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		title           string
+		expiresAtIsZero bool
+		expiresAtDiff   time.Duration
+		margin          time.Duration
+		required        bool
+		result          bool
+	}{
+		{
+			title:         "future_expiry",
+			expiresAtDiff: 5 * time.Minute,
+			margin:        10 * time.Second,
+			required:      true,
+			result:        true,
+		},
+		{
+			title:         "past_expiry",
+			expiresAtDiff: -5 * time.Hour,
+			margin:        10 * time.Second,
+			required:      true,
+			result:        false,
+		},
+		{
+			title:         "within_margin",
+			expiresAtDiff: 2 * time.Second,
+			margin:        10 * time.Second,
+			required:      true,
+			result:        false,
+		},
+		{
+			title:           "zero_required",
+			expiresAtIsZero: true,
+			margin:          10 * time.Second,
+			required:        true,
+			result:          false,
+		},
+		{
+			title:           "zero_not_required",
+			expiresAtIsZero: true,
+			margin:          10 * time.Second,
+			required:        false,
+			result:          true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s_%s", test.title, test.expiresAtDiff.String()), func(t *testing.T) {
+			t.Parallel()
+
+			now := time.Now().UTC()
+			expiresAt := time.Time{}
+			if !test.expiresAtIsZero {
+				expiresAt = now.Add(test.expiresAtDiff)
+			}
+			t.Logf("now: %s, expiresAt: %s\n", now.String(), expiresAt.String())
+
+			result := IsNotExpired(expiresAt, test.margin, test.required)
+			assert.Equal(t, test.result, result)
+		})
+	}
+}


### PR DESCRIPTION
Implement using internal authentication tokens from renku-data-services in `git-proxy` and in `remote-session-controller`.

See: https://github.com/SwissDataScienceCenter/renku-data-services/pull/1249

Note: code for handling token authentication in sidecars can be consolidated, will try to make it nicer in the future.