### PR TITLE
fix: handle reserved annotations for PVCs

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/internal/controller/amaltheasession_controller.go
+++ b/internal/controller/amaltheasession_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"time"
@@ -168,6 +169,18 @@ func (r *AmaltheaSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	newStatus := updates.Status(ctx, r, amaltheasession)
 	statusChanged := reflect.DeepEqual(amaltheasession.Status, newStatus)
 	log.Info("reconcile", "statusChanged", statusChanged)
+	if statusChanged {
+		oldJson, err1 := json.Marshal(amaltheasession.Status)
+		newJson, err2 := json.Marshal(newStatus)
+		if err1 != nil {
+			log.Error(err1, "reconcile debug failed")
+		} else if err2 != nil {
+			log.Error(err2, "reconcile debug failed")
+		} else {
+			log.Info("reconcile - statuses", "old", oldJson, "new", newJson)
+		}
+	}
+
 	amaltheasession.Status = newStatus
 	err = r.Status().Update(ctx, amaltheasession)
 	if err != nil {

--- a/internal/controller/amaltheasession_controller.go
+++ b/internal/controller/amaltheasession_controller.go
@@ -167,6 +167,7 @@ func (r *AmaltheaSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	newStatus := updates.Status(ctx, r, amaltheasession)
 	statusChanged := reflect.DeepEqual(amaltheasession.Status, newStatus)
+	log.Info("reconcile", "statusChanged", statusChanged)
 	amaltheasession.Status = newStatus
 	err = r.Status().Update(ctx, amaltheasession)
 	if err != nil {

--- a/internal/controller/amaltheasession_controller.go
+++ b/internal/controller/amaltheasession_controller.go
@@ -167,7 +167,7 @@ func (r *AmaltheaSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	newStatus := updates.Status(ctx, r, amaltheasession)
-	statusChanged := reflect.DeepEqual(amaltheasession.Status, newStatus)
+	statusChanged := !reflect.DeepEqual(amaltheasession.Status, newStatus)
 	log.Info("reconcile", "statusChanged", statusChanged)
 	if statusChanged {
 		oldJson, err1 := json.Marshal(amaltheasession.Status)
@@ -177,7 +177,7 @@ func (r *AmaltheaSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		} else if err2 != nil {
 			log.Error(err2, "reconcile debug failed")
 		} else {
-			log.Info("reconcile - statuses", "old", oldJson, "new", newJson)
+			log.Info("reconcile - statuses", "old", string(oldJson), "new", string(newJson))
 		}
 	}
 

--- a/internal/controller/amaltheasession_controller.go
+++ b/internal/controller/amaltheasession_controller.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"reflect"
 	"time"
@@ -34,9 +33,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	amaltheadevv1alpha1 "github.com/SwissDataScienceCenter/amalthea/api/v1alpha1"
 )
@@ -170,36 +167,20 @@ func (r *AmaltheaSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	newStatus := updates.Status(ctx, r, amaltheasession)
 	statusChanged := !reflect.DeepEqual(amaltheasession.Status, newStatus)
-	log.Info("reconcile", "statusChanged", statusChanged)
-	if statusChanged {
-		oldJson, err1 := json.Marshal(amaltheasession.Status)
-		newJson, err2 := json.Marshal(newStatus)
-		if err1 != nil {
-			log.Error(err1, "reconcile debug failed")
-		} else if err2 != nil {
-			log.Error(err2, "reconcile debug failed")
-		} else {
-			log.Info("reconcile - statuses", "old", string(oldJson), "new", string(newJson))
-		}
-	}
 
-	if statusChanged {
+	amaltheasession.Status = newStatus
+	err = r.Status().Update(ctx, amaltheasession)
+	if err != nil {
+		// The status update can fail if the CR is out of date, re-read the CR here and retry
+		err = r.Get(ctx, req.NamespacedName, amaltheasession)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 		amaltheasession.Status = newStatus
 		err = r.Status().Update(ctx, amaltheasession)
 		if err != nil {
-			// The status update can fail if the CR is out of date, re-read the CR here and retry
-			err = r.Get(ctx, req.NamespacedName, amaltheasession)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			amaltheasession.Status = newStatus
-			err = r.Status().Update(ctx, amaltheasession)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
+			return ctrl.Result{}, err
 		}
-	} else {
-		log.Info("reconcile: skip status write")
 	}
 
 	// Record metrics for the session status
@@ -224,7 +205,6 @@ func (r *AmaltheaSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// If the status is evolving we should requeue faster
 		requeueAfter = 0
 	}
-	log.Info("reconcile - requeue", "RequeueAfter", requeueAfter.String())
 	return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 }
 
@@ -251,20 +231,6 @@ func (r *AmaltheaSessionReconciler) deleteSecrets(ctx context.Context, cr *amalt
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AmaltheaSessionReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Debug hibernate spam
-	logger := log.FromContext(context.Background())
-	eventFilter := predicate.Funcs{
-		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
-			logger.Info("UpdateFunc", "event", e)
-			return true
-
-		},
-		GenericFunc: func(e event.TypedGenericEvent[client.Object]) bool {
-			logger.Info("GenericFunc", "event", e)
-			return true
-		},
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&amaltheadevv1alpha1.AmaltheaSession{}).
 		Owns(&appsv1.StatefulSet{}).
@@ -272,6 +238,5 @@ func (r *AmaltheaSessionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&networkingv1.Ingress{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.Secret{}).
-		WithEventFilter(eventFilter).
 		Complete(r)
 }

--- a/internal/controller/amaltheasession_controller.go
+++ b/internal/controller/amaltheasession_controller.go
@@ -34,7 +34,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	amaltheadevv1alpha1 "github.com/SwissDataScienceCenter/amalthea/api/v1alpha1"
 )
@@ -249,6 +251,20 @@ func (r *AmaltheaSessionReconciler) deleteSecrets(ctx context.Context, cr *amalt
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AmaltheaSessionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Debug hibernate spam
+	logger := log.FromContext(context.Background())
+	eventFilter := predicate.Funcs{
+		UpdateFunc: func(e event.TypedUpdateEvent[client.Object]) bool {
+			logger.Info("UpdateFunc", "event", e)
+			return true
+
+		},
+		GenericFunc: func(e event.TypedGenericEvent[client.Object]) bool {
+			logger.Info("GenericFunc", "event", e)
+			return true
+		},
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&amaltheadevv1alpha1.AmaltheaSession{}).
 		Owns(&appsv1.StatefulSet{}).
@@ -256,5 +272,6 @@ func (r *AmaltheaSessionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&networkingv1.Ingress{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.Secret{}).
+		WithEventFilter(eventFilter).
 		Complete(r)
 }

--- a/internal/controller/amaltheasession_controller.go
+++ b/internal/controller/amaltheasession_controller.go
@@ -181,19 +181,23 @@ func (r *AmaltheaSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
-	amaltheasession.Status = newStatus
-	err = r.Status().Update(ctx, amaltheasession)
-	if err != nil {
-		// The status update can fail if the CR is out of date, re-read the CR here and retry
-		err = r.Get(ctx, req.NamespacedName, amaltheasession)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+	if statusChanged {
 		amaltheasession.Status = newStatus
 		err = r.Status().Update(ctx, amaltheasession)
 		if err != nil {
-			return ctrl.Result{}, err
+			// The status update can fail if the CR is out of date, re-read the CR here and retry
+			err = r.Get(ctx, req.NamespacedName, amaltheasession)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			amaltheasession.Status = newStatus
+			err = r.Status().Update(ctx, amaltheasession)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 		}
+	} else {
+		log.Info("reconcile: skip status write")
 	}
 
 	// Record metrics for the session status
@@ -218,6 +222,7 @@ func (r *AmaltheaSessionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// If the status is evolving we should requeue faster
 		requeueAfter = 0
 	}
+	log.Info("reconcile - requeue", "RequeueAfter", requeueAfter.String())
 	return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 }
 

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -191,8 +191,22 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 					// NOTE: If the desired storage class is nil then the current spec contains the name for the default storage class
 					current.Spec.StorageClassName = desired.Spec.StorageClassName
 				}
+				// Do not touch reserved labels and annotations
+				// Reference: https://kubernetes.io/docs/reference/labels-annotations-taints/
+				// TODO: handle labels
 				current.Labels = desired.Labels
+				preservedAnnotations := map[string]string{}
+				for key := range current.Annotations {
+					domain, _, _ := strings.Cut(key, "/")
+					if domain == "kubernetes.io" || domain == "k8s.io" || strings.HasSuffix(domain, ".kubernetes.io") ||
+						strings.HasSuffix(domain, ".k8s.io") {
+						preservedAnnotations[key] = current.Annotations[key]
+					}
+				}
 				current.Annotations = desired.Annotations
+				for key := range preservedAnnotations {
+					current.Annotations[key] = preservedAnnotations[key]
+				}
 			default:
 				return fmt.Errorf("attempting to reconcile PVC with unknown stategy %s", strategy)
 			}

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -172,10 +171,6 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 				current.ObjectMeta = desired.ObjectMeta
 				err := ctrl.SetControllerReference(cr, current, clnt.Scheme())
 				return err
-			}
-			if reflect.DeepEqual(*current, *desired) {
-				log.Info("reconcile", "message", "current deep equals desired")
-				return nil
 			}
 			switch strategy := cr.Spec.ReconcileStrategy; strategy {
 			case amaltheadevv1alpha1.Never:

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -199,6 +199,9 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 					}
 				}
 				current.Annotations = desired.Annotations
+				if current.Annotations == nil {
+					current.Annotations = map[string]string{}
+				}
 				for key := range preservedAnnotations {
 					current.Annotations[key] = preservedAnnotations[key]
 				}

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -171,6 +172,10 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 				current.ObjectMeta = desired.ObjectMeta
 				err := ctrl.SetControllerReference(cr, current, clnt.Scheme())
 				return err
+			}
+			if reflect.DeepEqual(*current, *desired) {
+				log.Info("reconcile", "message", "current deep equals desired")
+				return nil
 			}
 			switch strategy := cr.Spec.ReconcileStrategy; strategy {
 			case amaltheadevv1alpha1.Never:


### PR DESCRIPTION
Closes #1102.

Details:
1. fix the `reconcileAfter` logic
2. handle reserved annotations for PVCs

TODO: refactor to make re-usable util functions for reserved labels, annotations and taints.

/deploy