### PR TITLE
fix: using https in the url in the status

### DIFF
--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -219,11 +219,19 @@ type Ingress struct {
 	// account if `TLSSecret` above is left unset, if the `TLSSecret` field is set
 	// then that value will take precedence and this boolean flag will be ignored.
 	UseDefaultClusterTLSCert bool `json:"useDefaultClusterTLSCert,omitempty"`
+	// +optional
+	// +kubebuilder:default:=false
+	// If set to true Amalthea will template HTTPS for the URL to access the session
+	// that is reported in the status. Without trying to guess whether to use HTTP or HTTPS
+	// based on the TLS secret or other configurations provided. The reason for this flag
+	// is that sometimes TLS secret can be provisioned simply by adding ingress annotations.
+	// And in this case we cannot determine the right scheme reliably from the session spec.
+	AssumeHttps bool `json:"assumeHttps,omitempty"`
 }
 
 func (ingress *Ingress) UrlScheme() string {
 	urlScheme := "http"
-	if (ingress.TLSSecret != nil && ingress.TLSSecret.Name != "") || ingress.UseDefaultClusterTLSCert {
+	if (ingress.TLSSecret != nil && ingress.TLSSecret.Name != "") || ingress.UseDefaultClusterTLSCert || ingress.AssumeHttps {
 		urlScheme = "https"
 	}
 	return urlScheme

--- a/bundle/manifests/amalthea.dev_amaltheasessions.yaml
+++ b/bundle/manifests/amalthea.dev_amaltheasessions.yaml
@@ -4534,6 +4534,15 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  assumeHttps:
+                    default: false
+                    description: |-
+                      If set to true Amalthea will template HTTPS for the URL to access the session
+                      that is reported in the status. Without trying to guess whether to use HTTP or HTTPS
+                      based on the TLS secret or other configurations provided. The reason for this flag
+                      is that sometimes TLS secret can be provisioned simply by adding ingress annotations.
+                      And in this case we cannot determine the right scheme reliably from the session spec.
+                    type: boolean
                   host:
                     type: string
                     x-kubernetes-validations:

--- a/config/crd/bases/amalthea.dev_amaltheasessions.yaml
+++ b/config/crd/bases/amalthea.dev_amaltheasessions.yaml
@@ -4534,6 +4534,15 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  assumeHttps:
+                    default: false
+                    description: |-
+                      If set to true Amalthea will template HTTPS for the URL to access the session
+                      that is reported in the status. Without trying to guess whether to use HTTP or HTTPS
+                      based on the TLS secret or other configurations provided. The reason for this flag
+                      is that sometimes TLS secret can be provisioned simply by adding ingress annotations.
+                      And in this case we cannot determine the right scheme reliably from the session spec.
+                    type: boolean
                   host:
                     type: string
                     x-kubernetes-validations:

--- a/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
+++ b/helm-chart/amalthea-sessions/templates/amaltheasession-crd.yaml
@@ -4536,6 +4536,15 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  assumeHttps:
+                    default: false
+                    description: |-
+                      If set to true Amalthea will template HTTPS for the URL to access the session
+                      that is reported in the status. Without trying to guess whether to use HTTP or HTTPS
+                      based on the TLS secret or other configurations provided. The reason for this flag
+                      is that sometimes TLS secret can be provisioned simply by adding ingress annotations.
+                      And in this case we cannot determine the right scheme reliably from the session spec.
+                    type: boolean
                   host:
                     type: string
                     x-kubernetes-validations:


### PR DESCRIPTION
We cant always reliably tell if we should use http or https in the session url.

So this new flag can help just override things to https.

We saw this case when running on a remote cluster where tls is provisioned from ingress annotations. So it is not an existing TLS secret and they are not using the clusterDefaultTLS secret either.