### PR TITLE
fix: allow overriding https for session ingress

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -611,6 +611,10 @@ func getUseNoneSameSiteSessionCookie() bool {
 	return strings.ToLower(os.Getenv("USE_NONE_SAME_SITE_SESSION_COOKIE")) == "true"
 }
 
+func getHttpsSessionIngress() bool {
+	return strings.ToLower(os.Getenv("HTTPS_SESSION_INGRESS")) == "true"
+}
+
 // InternalSecretName returns the name of the secret that is a child
 // of the AmaltheaSession CR, as opposed to all other adopted secrets that
 // are not children of the AmaltheaSession CR and are created by the creator of each AmaltheaSession CR.

--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -231,7 +231,7 @@ type Ingress struct {
 
 func (ingress *Ingress) UrlScheme() string {
 	urlScheme := "http"
-	if (ingress.TLSSecret != nil && ingress.TLSSecret.Name != "") || ingress.UseDefaultClusterTLSCert || ingress.AssumeHttps {
+	if (ingress.TLSSecret != nil && ingress.TLSSecret.Name != "") || ingress.UseDefaultClusterTLSCert || ingress.AssumeHttps || getHttpsSessionIngress() {
 		urlScheme = "https"
 	}
 	return urlScheme

--- a/helm-chart/amalthea-sessions/templates/deployment.yaml
+++ b/helm-chart/amalthea-sessions/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
           value: {{ .Values.sidecars.image.repository }}:{{ .Values.sidecars.image.tag }}
         - name: USE_NONE_SAME_SITE_SESSION_COOKIE
           value: {{ .Values.useNoneSameSiteSessionCookie | quote }}
+        - name: HTTPS_SESSION_INGRESS
+          value: {{ .Values.httpsSessionIngress | quote }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
           | default .Chart.AppVersion }}
         livenessProbe:

--- a/helm-chart/amalthea-sessions/values.yaml
+++ b/helm-chart/amalthea-sessions/values.yaml
@@ -72,3 +72,8 @@ cloner:
 # SameSite parameter to None. This is only useful in specific cases for remote Renku cluster.
 # Setting this value to true can have security implications without adjusting CSP and CORS on the session ingress.
 useNoneSameSiteSessionCookie: false
+
+# Setting this to true will result the url for the session always using https.
+# Regardless of whether a TLS secret or cluster-wide TLS secret is used.
+# This is useful because in many cases TLS can be provided through other means.
+httpsSessionIngress: false


### PR DESCRIPTION
Allows enabling https for remote clusters.