### PR TITLE
fix: correct branch name and resume session

### DIFF
--- a/internal/cloner/cloner.go
+++ b/internal/cloner/cloner.go
@@ -19,6 +19,11 @@ type Cloner struct {
 }
 
 func (c *Cloner) Run() error {
+	globalCli := NewGitCli("")
+	_, err := globalCli.Config([]string{"--global", "init.defaultBranch", "main"})
+	if err != nil {
+		log.Printf("Could not set global init.defaultBranch config: %s\n.", err.Error())
+	}
 	for _, repository := range c.config.Repositories {
 		log.Println("Processing", repository.URL)
 		err := c.execute(repository)
@@ -206,10 +211,12 @@ func (c *Cloner) clone(repository Repository) error {
 	} else {
 		branch = *repository.Branch
 	}
-	log.Println("Checking out branch", branch)
-	_, err = repository.Cli.Checkout([]string{branch})
-	if err != nil {
-		return err
+	if branch != "" {
+		log.Println("Checking out branch", branch)
+		_, err = repository.Cli.Checkout([]string{branch})
+		if err != nil {
+			return err
+		}
 	}
 
 	if c.config.LfsAutoFetch {

--- a/internal/cloner/cloner.go
+++ b/internal/cloner/cloner.go
@@ -36,10 +36,7 @@ func (c *Cloner) proxyURL() string {
 func (c *Cloner) execute(repository Repository) error {
 	log.Println("Checking if the repo already exists.")
 	if repository.Exists() {
-		err := c.setupProxy(repository)
-		if err != nil {
-			return err
-		}
+		return c.setupProxy(repository)
 	}
 
 	gitUser := "oauth2"

--- a/internal/cloner/cloner.go
+++ b/internal/cloner/cloner.go
@@ -19,7 +19,7 @@ type Cloner struct {
 }
 
 func (c *Cloner) Run() error {
-	globalCli := NewGitCli("")
+	globalCli := GitCli{"", "", ""}
 	_, err := globalCli.Config([]string{"--global", "init.defaultBranch", "main"})
 	if err != nil {
 		log.Printf("Could not set global init.defaultBranch config: %s\n.", err.Error())

--- a/internal/cloner/cloner.go
+++ b/internal/cloner/cloner.go
@@ -19,11 +19,6 @@ type Cloner struct {
 }
 
 func (c *Cloner) Run() error {
-	globalCli := GitCli{"", "", ""}
-	_, err := globalCli.Config([]string{"--global", "init.defaultBranch", "main"})
-	if err != nil {
-		log.Printf("Could not set global init.defaultBranch config: %s\n.", err.Error())
-	}
 	for _, repository := range c.config.Repositories {
 		log.Println("Processing", repository.URL)
 		err := c.execute(repository)
@@ -154,7 +149,7 @@ func (c *Cloner) getAccessToken(providerId string) (string, error) {
 func (c *Cloner) initializeRepository(repository Repository) error {
 	log.Println("Initializing repo")
 
-	_, err := repository.Cli.Init([]string{})
+	_, err := repository.Cli.Init([]string{"--initial-branch", "main"})
 	if err != nil {
 		return err
 	}

--- a/internal/cloner/cloner.go
+++ b/internal/cloner/cloner.go
@@ -34,10 +34,11 @@ func (c *Cloner) proxyURL() string {
 }
 
 func (c *Cloner) execute(repository Repository) error {
-	log.Println("Checking if the repo already exists.")
 	if repository.Exists() {
+		log.Println("Repository exists, skipping cloning.")
 		return c.setupProxy(repository)
 	}
+	log.Println("Setting up repository.")
 
 	gitUser := "oauth2"
 	var gitAccessToken string

--- a/internal/cloner/repository.go
+++ b/internal/cloner/repository.go
@@ -67,7 +67,9 @@ func (r *Repository) Exists() bool {
 func (r *Repository) DefaultBranch(remoteName string) (string, error) {
 	_, err := r.Cli.Remote([]string{"set-head", remoteName, "--auto"})
 	if err != nil {
-		return "", err
+		// Cannot determine remote HEAD: the repository is likely empty
+		log.Printf("Could not get remote HEAD: %s.\n", err.Error())
+		return "", nil
 	}
 	ref, err := r.Cli.SymbolicRef([]string{fmt.Sprintf("refs/remotes/%v/HEAD", remoteName)})
 	if err != nil {

--- a/internal/cloner/repository.go
+++ b/internal/cloner/repository.go
@@ -78,7 +78,6 @@ func (r *Repository) DefaultBranch(remoteName string) (string, error) {
 	rx := regexp.MustCompile(fmt.Sprintf(`refs/remotes/%v/(?P<branch>.*)`, remoteName))
 	match := rx.FindStringSubmatch(ref)
 	if match == nil {
-		// TODO: is this correct? check with an empty git repository
 		return "", fmt.Errorf("default branch does not exist")
 	}
 	branch := match[1]

--- a/internal/cloner/repository.go
+++ b/internal/cloner/repository.go
@@ -74,11 +74,12 @@ func (r *Repository) DefaultBranch(remoteName string) (string, error) {
 		return "", err
 	}
 	rx := regexp.MustCompile(fmt.Sprintf(`refs/remotes/%v/(?P<branch>.*)`, remoteName))
-	branch := rx.FindString(ref)
-
-	if branch == "" {
-		return "", fmt.Errorf("branch does not exist")
+	match := rx.FindStringSubmatch(ref)
+	if match == nil {
+		// TODO: is this correct? check with an empty git repository
+		return "", fmt.Errorf("default branch does not exist")
 	}
+	branch := match[1]
 	log.Println("Default branch is", branch)
 	return branch, nil
 }


### PR DESCRIPTION
Fixes:
* Closes #1115: parse the branch name, the git repository tracks the default remote branch
* Closes #1114: correctly skip git cloning when resuming, re-set the git-proxy settings as expected
* Fixes cloning an empty repository

/deploy #notest extra-values=notebooks.gitClone.image.name=renku/cloner,notebooks.gitClone.image.tag=0.27.2-0.dev.git.368.h8171201