### PR TITLE
fix: remove debugging printing in git helper

### DIFF
--- a/env-pass.sh
+++ b/env-pass.sh
@@ -3,9 +3,6 @@
 set -eu
 set -o pipefail
 
-# Redirect to stderr so as to not interfere with the stdout needed for username/password prompts
-printenv >&2 # Do not try echo "$GIT_PREFIX", it doesn't seem to be inherited by this process
-
 case "$1" in
     Username*) exec echo "$GIT_USERNAME" ;;
     Password*) exec echo "$GIT_PASSWORD" ;;


### PR DESCRIPTION
## Describe your changes

Removed environment printing from git helper script.

It was used to help debug the functionnality.

## Tickets and links

Fixes #1117

