### PR TITLE
fix: safe default for SessionType if the CRD is not up-to-date

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -102,11 +102,10 @@ func (cr *AmaltheaSession) Pod(cfg config.AmaltheaSessionConfiguration) (*v1.Pod
 	_, dsVols, dsVolMounts := cr.DataSources()
 	cloneInit := cr.cloneInit()
 	sessionVols, sessionMounts := cr.SessionVolumes()
-	isInteractive := cr.Spec.SessionType.IsInteractive()
 
 	var auth = manifests{}
 	// auth containers are only for interactive sessions
-	if isInteractive {
+	if cr.Spec.SessionType != SessionTypeNonInteractive {
 		var err error
 		auth, err = cr.auth()
 		if err != nil {
@@ -486,7 +485,7 @@ func (cr *AmaltheaSession) NeedsDeletion() bool {
 
 func (cr *AmaltheaSession) GetPod(ctx context.Context, clnt client.Client) (*v1.Pod, error) {
 	log := log.FromContext(ctx)
-	if cr.Spec.SessionType.IsNonInteractive() {
+	if cr.Spec.SessionType == SessionTypeNonInteractive {
 		selector := labels.Set{"job-name": cr.JobName()}.AsSelector()
 		podList := &v1.PodList{}
 		listOpts := &client.ListOptions{Namespace: cr.Namespace, LabelSelector: selector}

--- a/api/v1alpha1/amaltheasession_types.go
+++ b/api/v1alpha1/amaltheasession_types.go
@@ -646,11 +646,3 @@ const (
 	SessionTypeInteractive    SessionType = "Interactive"
 	SessionTypeNonInteractive SessionType = "NonInteractive"
 )
-
-func (t *SessionType) IsInteractive() bool {
-	return t == nil || *t == SessionTypeInteractive
-}
-
-func (t *SessionType) IsNonInteractive() bool {
-	return !t.IsInteractive()
-}

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -762,7 +762,7 @@ func (c ChildResourceUpdates) Status(
 		if state == amaltheadevv1alpha1.Running && oldEnough {
 			idleSince, idle = getIdleState(ctx, r, cr)
 		}
-		if cr.Spec.SessionType.IsNonInteractive() {
+		if cr.Spec.SessionType == amaltheadevv1alpha1.SessionTypeNonInteractive {
 			if (state == amaltheadevv1alpha1.Succeeded || state == amaltheadevv1alpha1.Failed) && idleSince.IsZero() {
 				// set idle time when containers exited
 				idleSince = metav1.NewTime(time.Now())


### PR DESCRIPTION
This change makes amalthea work when the installed CRD is pre-job (no `SessionType` field).

/deploy