### PR TITLE
Add capabilities.drop=ALL to all container security contexts

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -927,6 +927,9 @@ func (cr *AmaltheaSession) sessionContainerLocal(volumeMounts []v1.VolumeMount, 
 		RunAsNonRoot: ptr.To(true),
 		RunAsUser:    ptr.To(session.RunAsUser),
 		RunAsGroup:   ptr.To(session.RunAsGroup),
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{"ALL"},
+		},
 	}
 	if session.RunAsUser == 0 {
 		securityContext.RunAsNonRoot = ptr.To(false)
@@ -953,6 +956,9 @@ func (cr *AmaltheaSession) sessionContainerRemote(volumeMounts []v1.VolumeMount)
 		SecurityContext: &v1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.To(false),
 			RunAsNonRoot:             ptr.To(true),
+			Capabilities: &v1.Capabilities{
+				Drop: []v1.Capability{"ALL"},
+			},
 		},
 		Args: []string{
 			"remote-session-controller",

--- a/api/v1alpha1/auth_templates.go
+++ b/api/v1alpha1/auth_templates.go
@@ -57,6 +57,9 @@ func (as *AmaltheaSession) auth() (manifests, error) {
 			SecurityContext: &v1.SecurityContext{
 				AllowPrivilegeEscalation: ptr.To(false),
 				RunAsNonRoot:             ptr.To(true),
+				Capabilities: &v1.Capabilities{
+					Drop: []v1.Capability{"ALL"},
+				},
 			},
 			Args: []string{
 				fmt.Sprintf("--upstream=%s", fmt.Sprintf("http://127.0.0.1:%d", secondProxyPort)),
@@ -161,6 +164,9 @@ func (as *AmaltheaSession) auth() (manifests, error) {
 			SecurityContext: &v1.SecurityContext{
 				AllowPrivilegeEscalation: ptr.To(false),
 				RunAsNonRoot:             ptr.To(true),
+				Capabilities: &v1.Capabilities{
+					Drop: []v1.Capability{"ALL"},
+				},
 			},
 			Args: []string{
 				"--silence-ping-logging",
@@ -230,6 +236,9 @@ func (as *AmaltheaSession) get_rewrite_authn_proxy(listenPort int32, metaListenP
 			RunAsNonRoot:             ptr.To(true),
 			RunAsUser:                ptr.To(int64(1000)),
 			RunAsGroup:               ptr.To(int64(1000)),
+			Capabilities: &v1.Capabilities{
+				Drop: []v1.Capability{"ALL"},
+			},
 		},
 		Args: []string{
 			"proxy",

--- a/api/v1alpha1/code_repo_templates.go
+++ b/api/v1alpha1/code_repo_templates.go
@@ -61,6 +61,9 @@ func (as *AmaltheaSession) cloneInit() manifests {
 			SecurityContext: &v1.SecurityContext{
 				RunAsUser:  &as.Spec.Session.RunAsUser,
 				RunAsGroup: &as.Spec.Session.RunAsGroup,
+				Capabilities: &v1.Capabilities{
+					Drop: []v1.Capability{"ALL"},
+				},
 			},
 			Args: args,
 		})


### PR DESCRIPTION
In my testing I have found out that this is also sufficient to block exploits like Copy-Fail(CVE-2026-31431) and Dirty-Frag(CVE-2026-43284, CVE-2026-43500).

Additionally it is probably a good idea to drop all capabilities from Renku user-sessions to limit the surface of attack.

/deploy
