### PR TITLE
fix: session_script.sh: magic line has to be first

### DIFF
--- a/internal/remote/firecrest/session_script.sh
+++ b/internal/remote/firecrest/session_script.sh
@@ -1,10 +1,11 @@
+#!/bin/bash
+
 # NOTE FOR AMALTHEA MAINTAINERS:
 #   This script contains template strings in the following form:
 #     `#{{NAME}}`
 #   These strings should be added or removed according to code changes
 #   in the remote session controller.
 # END NOTE
-#!/bin/bash
 #{{SBATCH_DIRECTIVES_PLACEHOLDER}}
 
 set -e -o pipefail

--- a/internal/remote/firecrest/session_script.sh
+++ b/internal/remote/firecrest/session_script.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # NOTE FOR AMALTHEA MAINTAINERS:
 #   This script contains template strings in the following form:
 #     `#{{NAME}}`


### PR DESCRIPTION
The magic line/interpreter line has to be the first of the file, otherwise it is simply ignored.