### PR TITLE
fix: Handle all firecrest FS types

### DIFF
--- a/internal/remote/firecrest/controller.go
+++ b/internal/remote/firecrest/controller.go
@@ -635,40 +635,30 @@ func addSessionMountsToScript(sessionScript string, fileSystems *[]FileSystem, s
 	if fileSystems == nil {
 		return strings.Replace(sessionScript, "#{{SESSION_MOUNTS_PLACEHOLDER}}", "", 1)
 	}
-	// Collect file systems we want to mount
-	var home *FileSystem
-	scratches, stores := []*FileSystem{}, []*FileSystem{}
+
+	// Collect file systems we want to mount as "SRC:DST[:FLAG]" strings
+	var mounts []string
 	for _, fs := range *fileSystems {
 		switch fs.DataType {
-		case Scratch:
-			scratches = append(scratches, &fs)
-		case Store:
-			stores = append(stores, &fs)
 		case Users:
-			home = &fs
+			// TODO: Try to mount home at its location (need to handle ~/.bashrc)
+			// TODO: Alternatively, copy the contents in the container
+			mounts = append(mounts, fmt.Sprintf("%s/${USER}:/home/%s/${USER}:ro", fs.Path, fs.Path))
+		default:
+			// Identity mapping of the host mounts
+			mounts = append(mounts, fmt.Sprintf("%s:%s", fs.Path, fs.Path))
 		}
 	}
 
-	mounts := []string{}
-	for _, scratch := range scratches {
-		mounts = append(mounts, scratch.Path)
-	}
-	for _, store := range stores {
-		mounts = append(mounts, store.Path)
-	}
-	// TODO: Try to mount home at its location (need to handle ~/.bashrc)
-	// TODO: Alternatively, copy the contents in the container
-	if home != nil {
-		mounts = append(mounts, fmt.Sprintf("%s:/home%s:ro", home.Path, home.Path))
+	// Add the secrets mount
+	if len(secretsPath) > 0 {
+		mounts = append(mounts, fmt.Sprintf("%s:/secrets:ro", secretsPath))
 	}
 
-	// Add the secrets mount
-	mounts = append(mounts, fmt.Sprintf("%s:/secrets:ro", secretsPath))
-	// Format mount list
+	// Format mount list for the environment.toml file
 	for i := range mounts {
 		mounts[i] = fmt.Sprintf("    \"%s\",", mounts[i])
 	}
-
 	mountsStr := fmt.Sprintf("mounts = [\n%s\n]", strings.Join(mounts, "\n"))
 	return strings.Replace(sessionScript, "#{{SESSION_MOUNTS_PLACEHOLDER}}", mountsStr, 1)
 }

--- a/internal/remote/firecrest/controller.go
+++ b/internal/remote/firecrest/controller.go
@@ -643,7 +643,7 @@ func addSessionMountsToScript(sessionScript string, fileSystems *[]FileSystem, s
 		case Users:
 			// TODO: Try to mount home at its location (need to handle ~/.bashrc)
 			// TODO: Alternatively, copy the contents in the container
-			mounts = append(mounts, fmt.Sprintf("%s/${USER}:/home%s/${USER}:ro", fs.Path, fs.Path))
+			mounts = append(mounts, fmt.Sprintf("%s:/home%s:ro", fs.Path, fs.Path))
 		default:
 			// Identity mapping of the host mounts
 			mounts = append(mounts, fmt.Sprintf("%s:%s", fs.Path, fs.Path))

--- a/internal/remote/firecrest/controller.go
+++ b/internal/remote/firecrest/controller.go
@@ -643,7 +643,7 @@ func addSessionMountsToScript(sessionScript string, fileSystems *[]FileSystem, s
 		case Users:
 			// TODO: Try to mount home at its location (need to handle ~/.bashrc)
 			// TODO: Alternatively, copy the contents in the container
-			mounts = append(mounts, fmt.Sprintf("%s/${USER}:/home/%s/${USER}:ro", fs.Path, fs.Path))
+			mounts = append(mounts, fmt.Sprintf("%s/${USER}:/home%s/${USER}:ro", fs.Path, fs.Path))
 		default:
 			// Identity mapping of the host mounts
 			mounts = append(mounts, fmt.Sprintf("%s:%s", fs.Path, fs.Path))

--- a/internal/remote/firecrest/controller.go
+++ b/internal/remote/firecrest/controller.go
@@ -651,7 +651,7 @@ func addSessionMountsToScript(sessionScript string, fileSystems *[]FileSystem, s
 	}
 
 	// Add the secrets mount
-	if len(secretsPath) > 0 {
+	if secretsPath != "" {
 		mounts = append(mounts, fmt.Sprintf("%s:/secrets:ro", secretsPath))
 	}
 

--- a/internal/remote/firecrest/controller_test.go
+++ b/internal/remote/firecrest/controller_test.go
@@ -54,8 +54,8 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 	matches := mountsRegExp.FindStringSubmatch(sessionScriptFinal)
 	assert.Len(t, matches, 2)
 	foundMounts := matches[1]
-	assert.Contains(t, foundMounts, "\"/scratch\"")
-	assert.Contains(t, foundMounts, "\"/store\"")
-	assert.Contains(t, foundMounts, "\"/users:/home/users:ro\"")
+	assert.Contains(t, foundMounts, "\"/scratch:/scratch\"")
+	assert.Contains(t, foundMounts, "\"/store:/store\"")
+	assert.Contains(t, foundMounts, "\"/users/${USER}:/home/users/${USER}:ro\"")
 	assert.Contains(t, foundMounts, "\"/secrets:/secrets:ro\"")
 }

--- a/internal/remote/firecrest/controller_test.go
+++ b/internal/remote/firecrest/controller_test.go
@@ -79,7 +79,7 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 	assert.Contains(t, foundMounts, "\"/project:/project\"")
 	assert.Contains(t, foundMounts, "\"/scratch:/scratch\"")
 	assert.Contains(t, foundMounts, "\"/store:/store\"")
-	assert.Contains(t, foundMounts, "\"/users/${USER}:/home/users/${USER}:ro\"")
+	assert.Contains(t, foundMounts, "\"/users:/home/users:ro\"")
 	assert.Contains(t, foundMounts, "\"/secrets:/secrets:ro\"")
 	assert.Contains(t, foundMounts, "\"/cluster-specific:/cluster-specific\"")
 }

--- a/internal/remote/firecrest/controller_test.go
+++ b/internal/remote/firecrest/controller_test.go
@@ -51,6 +51,11 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 			DefaultWorkDir: ptr.To(false),
 			Path:           "/users",
 		},
+		{
+			DataType:       "custom-not-part-of-enum",
+			DefaultWorkDir: ptr.To(false),
+			Path:           "/cluster-specific",
+		},
 	}
 	secretsPath := "/secrets"
 
@@ -76,4 +81,5 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 	assert.Contains(t, foundMounts, "\"/store:/store\"")
 	assert.Contains(t, foundMounts, "\"/users/${USER}:/home/users/${USER}:ro\"")
 	assert.Contains(t, foundMounts, "\"/secrets:/secrets:ro\"")
+	assert.Contains(t, foundMounts, "\"/cluster-specific:/cluster-specific\"")
 }

--- a/internal/remote/firecrest/controller_test.go
+++ b/internal/remote/firecrest/controller_test.go
@@ -22,6 +22,21 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 	partition := "my-partition"
 	fileSystems := []FileSystem{
 		{
+			DataType:       "apps",
+			DefaultWorkDir: ptr.To(true),
+			Path:           "/apps",
+		},
+		{
+			DataType:       "archive",
+			DefaultWorkDir: ptr.To(false),
+			Path:           "/archive",
+		},
+		{
+			DataType:       "project",
+			DefaultWorkDir: ptr.To(false),
+			Path:           "/project",
+		},
+		{
 			DataType:       "scratch",
 			DefaultWorkDir: ptr.To(true),
 			Path:           "/scratch",
@@ -54,6 +69,9 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 	matches := mountsRegExp.FindStringSubmatch(sessionScriptFinal)
 	assert.Len(t, matches, 2)
 	foundMounts := matches[1]
+	assert.Contains(t, foundMounts, "\"/apps:/apps\"")
+	assert.Contains(t, foundMounts, "\"/archive:/archive\"")
+	assert.Contains(t, foundMounts, "\"/project:/project\"")
 	assert.Contains(t, foundMounts, "\"/scratch:/scratch\"")
 	assert.Contains(t, foundMounts, "\"/store:/store\"")
 	assert.Contains(t, foundMounts, "\"/users/${USER}:/home/users/${USER}:ro\"")


### PR DESCRIPTION
* Simplify the logic, as we only want to handle specifically the "Users" fs type for now.
* Check secretPath and add it only if the string is not empty.