### PR TITLE
fix: Only check pod phase in isPodReady

### DIFF
--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -21,10 +21,17 @@ func containerCounts(pod *v1.Pod) (amaltheadevv1alpha1.ContainerCounts, amalthea
 	if pod == nil {
 		return initCounts, counts
 	}
+
 	for _, container := range pod.Status.InitContainerStatuses {
-		containerCompleted := container.State.Terminated != nil && container.State.Terminated.ExitCode == 0 && container.State.Terminated.Reason == "Completed"
+		var containerOk bool
+		if isContainerSidecar(container, *pod) {
+			containerOk = container.Ready && container.State.Running != nil
+		} else {
+			containerOk = container.State.Terminated != nil && container.State.Terminated.ExitCode == 0 && container.State.Terminated.Reason == "Completed"
+		}
+
 		initCounts.Total += 1
-		if containerCompleted {
+		if containerOk {
 			initCounts.Ready += 1
 		}
 	}
@@ -39,15 +46,34 @@ func containerCounts(pod *v1.Pod) (amaltheadevv1alpha1.ContainerCounts, amalthea
 	return initCounts, counts
 }
 
+func containerRestartPolicy(status v1.ContainerStatus, pod v1.Pod) *v1.ContainerRestartPolicy {
+	for _, c := range pod.Spec.Containers {
+		if c.Name == status.Name {
+			return c.RestartPolicy
+		}
+	}
+	return nil
+}
+
+func isContainerSidecar(status v1.ContainerStatus, pod v1.Pod) bool {
+	restartPolicy := containerRestartPolicy(status, pod)
+	if restartPolicy != nil {
+		switch *restartPolicy {
+		case v1.ContainerRestartPolicyAlways:
+			return true
+		}
+	}
+	return false
+}
+
 func podIsReady(pod *v1.Pod) bool {
 	if pod == nil || pod.GetDeletionTimestamp() != nil {
 		// A missing pod or a pod being deleted is not considered ready
 		return false
 	}
 	phaseOk := pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodRunning
-	// initCounts, counts := containerCounts(pod)
-	// return initCounts.Ok() && counts.Ok() && phaseOk
-	return phaseOk
+	initCounts, counts := containerCounts(pod)
+	return initCounts.Ok() && counts.Ok() && phaseOk
 }
 
 func podIsCompleted(pod *v1.Pod) bool {

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -26,6 +26,7 @@ func containerCounts(pod *v1.Pod) (amaltheadevv1alpha1.ContainerCounts, amalthea
 		var containerOk bool
 		if isContainerSidecar(container, *pod) {
 			containerOk = container.Ready && container.State.Running != nil
+			fmt.Println(">>>>> Container is sidecar: ", container.Name, " ready: ", container.Ready, " running: ", container.State.Running)
 		} else {
 			containerOk = container.State.Terminated != nil && container.State.Terminated.ExitCode == 0 && container.State.Terminated.Reason == "Completed"
 		}
@@ -49,6 +50,7 @@ func containerCounts(pod *v1.Pod) (amaltheadevv1alpha1.ContainerCounts, amalthea
 func containerRestartPolicy(status v1.ContainerStatus, pod v1.Pod) *v1.ContainerRestartPolicy {
 	for _, c := range pod.Spec.Containers {
 		if c.Name == status.Name {
+			fmt.Println(">>>>>> RestartPolicy: ", c.RestartPolicy)
 			return c.RestartPolicy
 		}
 	}
@@ -67,6 +69,20 @@ func isContainerSidecar(status v1.ContainerStatus, pod v1.Pod) bool {
 }
 
 func podIsReady(pod *v1.Pod) bool {
+	if pod == nil || pod.GetDeletionTimestamp() != nil {
+		return false
+	}
+	phaseOk := pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodRunning
+	condOk := false
+	for _, c := range pod.Status.Conditions {
+		if c.Type == v1.PodReady && c.Status == v1.ConditionTrue {
+			condOk = true
+		}
+	}
+	return phaseOk && condOk
+}
+
+func podIsReady_prev(pod *v1.Pod) bool {
 	if pod == nil || pod.GetDeletionTimestamp() != nil {
 		// A missing pod or a pod being deleted is not considered ready
 		return false

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -45,8 +45,9 @@ func podIsReady(pod *v1.Pod) bool {
 		return false
 	}
 	phaseOk := pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodRunning
-	initCounts, counts := containerCounts(pod)
-	return initCounts.Ok() && counts.Ok() && phaseOk
+	// initCounts, counts := containerCounts(pod)
+	// return initCounts.Ok() && counts.Ok() && phaseOk
+	return phaseOk
 }
 
 func podIsCompleted(pod *v1.Pod) bool {

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -26,7 +26,6 @@ func containerCounts(pod *v1.Pod) (amaltheadevv1alpha1.ContainerCounts, amalthea
 		var containerOk bool
 		if isContainerSidecar(container, *pod) {
 			containerOk = container.Ready && container.State.Running != nil
-			fmt.Println(">>>>> Container is sidecar: ", container.Name, " ready: ", container.Ready, " running: ", container.State.Running)
 		} else {
 			containerOk = container.State.Terminated != nil && container.State.Terminated.ExitCode == 0 && container.State.Terminated.Reason == "Completed"
 		}
@@ -50,7 +49,6 @@ func containerCounts(pod *v1.Pod) (amaltheadevv1alpha1.ContainerCounts, amalthea
 func containerRestartPolicy(status v1.ContainerStatus, pod v1.Pod) *v1.ContainerRestartPolicy {
 	for _, c := range pod.Spec.Containers {
 		if c.Name == status.Name {
-			fmt.Println(">>>>>> RestartPolicy: ", c.RestartPolicy)
 			return c.RestartPolicy
 		}
 	}
@@ -68,7 +66,7 @@ func isContainerSidecar(status v1.ContainerStatus, pod v1.Pod) bool {
 	return false
 }
 
-func podIsReady_n(pod *v1.Pod) bool {
+func podIsReady(pod *v1.Pod) bool {
 	if pod == nil || pod.GetDeletionTimestamp() != nil {
 		return false
 	}
@@ -80,16 +78,6 @@ func podIsReady_n(pod *v1.Pod) bool {
 		}
 	}
 	return phaseOk && condOk
-}
-
-func podIsReady(pod *v1.Pod) bool {
-	if pod == nil || pod.GetDeletionTimestamp() != nil {
-		// A missing pod or a pod being deleted is not considered ready
-		return false
-	}
-	phaseOk := pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodRunning
-	initCounts, counts := containerCounts(pod)
-	return initCounts.Ok() && counts.Ok() && phaseOk
 }
 
 func podIsCompleted(pod *v1.Pod) bool {

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -68,7 +68,7 @@ func isContainerSidecar(status v1.ContainerStatus, pod v1.Pod) bool {
 	return false
 }
 
-func podIsReady(pod *v1.Pod) bool {
+func podIsReady_n(pod *v1.Pod) bool {
 	if pod == nil || pod.GetDeletionTimestamp() != nil {
 		return false
 	}
@@ -82,7 +82,7 @@ func podIsReady(pod *v1.Pod) bool {
 	return phaseOk && condOk
 }
 
-func podIsReady_prev(pod *v1.Pod) bool {
+func podIsReady(pod *v1.Pod) bool {
 	if pod == nil || pod.GetDeletionTimestamp() != nil {
 		// A missing pod or a pod being deleted is not considered ready
 		return false


### PR DESCRIPTION
This fixes determining readiness of pod containers. If a sidecar container is added to the `initContainers` of a pod, the status check must check a `Running` state and not a `Terminated` state.

The `podIsReady` function is rewritten to make use of the container status conditions. If a condition exists with `Type=Ready` and `Status=True`, it is considered ready. This removes the investigation of container status.

/deploy