### PR TITLE
fix: properly clean up finished jobs and return failure when max-age exceeded

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -180,13 +180,6 @@ func (cr *AmaltheaSession) Job(cfg config.AmaltheaSessionConfiguration) (batchv1
 		activeTTL = ptr.To(int64(cr.Spec.Culling.MaxAge.Seconds()))
 	}
 
-	// use MaxHibernatedDuration (amount of time until a hibernated session is deleted) to set the time
-	// after which the job is removed after it has completed
-	var ttlFinish *int32
-	if cr.Spec.Culling.MaxHibernatedDuration.Seconds() > 0 {
-		ttlFinish = ptr.To(int32(cr.Spec.Culling.MaxHibernatedDuration.Seconds()))
-	}
-
 	job := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cr.JobName(),
@@ -195,12 +188,11 @@ func (cr *AmaltheaSession) Job(cfg config.AmaltheaSessionConfiguration) (batchv1
 			Annotations: cr.Spec.Template.Metadata.Annotations,
 		},
 		Spec: batchv1.JobSpec{
-			Parallelism:             ptr.To(int32(1)),
-			Completions:             ptr.To(int32(1)),
-			BackoffLimit:            ptr.To(int32(0)),
-			ActiveDeadlineSeconds:   activeTTL,
-			TTLSecondsAfterFinished: ttlFinish,
-			Suspend:                 &cr.Spec.Hibernated,
+			Parallelism:           ptr.To(int32(1)),
+			Completions:           ptr.To(int32(1)),
+			BackoffLimit:          ptr.To(int32(0)),
+			ActiveDeadlineSeconds: activeTTL,
+			Suspend:               &cr.Spec.Hibernated,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      cr.childLabels(),

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -302,7 +302,7 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 				return fmt.Errorf("could not cast when reconciling")
 			}
 			// finished jobs are not updated
-			if jobIsCompleted(current.Status) {
+			if jobIsFinished(current.Status) {
 				log.Info("Job is terminated, not reconciling", "job", current.Name)
 				return nil
 			}

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -301,6 +301,11 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 			if !ok {
 				return fmt.Errorf("could not cast when reconciling")
 			}
+			// finished jobs are not updated
+			if jobIsCompleted(current.Status) {
+				log.Info("Job is terminated, not reconciling", "job", current.Name)
+				return nil
+			}
 			if current.CreationTimestamp.IsZero() {
 				log.Info("Creating a Job", "job", desired.Spec)
 				current.Spec = desired.Spec
@@ -310,11 +315,6 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 					log.Error(err, "Error setting controller reference")
 				}
 				return err
-			}
-			// finished jobs are not updated
-			if jobIsCompleted(current.Status) {
-				log.Info("Job is terminated, not reconciling", "job", current.Name)
-				return nil
 			}
 
 			// suspending jobs

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -311,8 +311,9 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 				}
 				return err
 			}
-			// finished jobs or those that are terminating are not updated
-			if current.Status.Terminating != nil || current.Status.Failed > 0 || current.Status.Succeeded > 0 {
+			// finished jobs are not updated
+			if jobIsCompleted(current.Status) {
+				log.Info("Job is terminated, not reconciling", "job", current.Name)
 				return nil
 			}
 

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -334,6 +334,8 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 			current.Spec.Template.Spec.NodeSelector = desired.Spec.Template.Spec.NodeSelector
 			current.Spec.Template.Spec.PriorityClassName = desired.Spec.Template.Spec.PriorityClassName
 			current.Spec.Suspend = desired.Spec.Suspend
+			current.Spec.ActiveDeadlineSeconds = desired.Spec.ActiveDeadlineSeconds
+			current.Spec.TTLSecondsAfterFinished = desired.Spec.TTLSecondsAfterFinished
 			switch strategy := cr.Spec.ReconcileStrategy; strategy {
 			case amaltheadevv1alpha1.Never:
 				return nil

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -311,6 +311,10 @@ func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr 
 				}
 				return err
 			}
+			// finished jobs or those that are terminating are not updated
+			if current.Status.Terminating != nil || current.Status.Failed > 0 || current.Status.Succeeded > 0 {
+				return nil
+			}
 
 			// suspending jobs
 			if current.Spec.Suspend != nil && desired.Spec.Suspend != nil && *current.Spec.Suspend && !*desired.Spec.Suspend {
@@ -537,6 +541,10 @@ func (c ChildResourceUpdates) failureMessage(pod *v1.Pod) string {
 		return msg
 	}
 	msg = ingressFailureReason(c.Ingress.Manifest)
+	if msg != "" {
+		return msg
+	}
+	msg = jobFailureReason(c.Job.Manifest)
 	if msg != "" {
 		return msg
 	}

--- a/internal/controller/children_conditions.go
+++ b/internal/controller/children_conditions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 )
@@ -24,6 +25,22 @@ func handleBadWaitingState(status v1.ContainerStatus) string {
 	}
 
 	return fmt.Sprintf("the container %s is failing because %s", status.Name, waitingState.Reason)
+}
+
+func jobFailureReason(job *batchv1.Job) string {
+	if job == nil {
+		return ""
+	}
+
+	if job.Status.Failed > 0 {
+		for _, cond := range job.Status.Conditions {
+			if (cond.Type == batchv1.JobFailed || cond.Type == batchv1.JobFailureTarget) && cond.Status == v1.ConditionTrue {
+				return cond.Reason + ": " + cond.Message
+			}
+		}
+		return "The job failed."
+	}
+	return ""
 }
 
 func podFailureReason(pod *v1.Pod) string {

--- a/internal/controller/cull.go
+++ b/internal/controller/cull.go
@@ -30,10 +30,15 @@ import (
 )
 
 func updateHibernationState(ctx context.Context, r *AmaltheaSessionReconciler, amaltheasession *amaltheadevv1alpha1.AmaltheaSession) error {
+	if amaltheasession.Spec.SessionType == amaltheadevv1alpha1.SessionTypeNonInteractive {
+		// non-interactive sessions (jobs) never get auto-scaled down by amalthea;
+		// this is managed by k8s via the activeDeadlineSeconds setting for jobs
+		return nil
+	}
+
 	status := amaltheasession.Status
 	log := log.FromContext(ctx)
-	interactive := amaltheasession.Spec.SessionType == amaltheadevv1alpha1.SessionTypeInteractive
-	if !amaltheasession.Spec.Hibernated && interactive { // hibernating only applies to interactive sessions, jobs are managed for that by k8s
+	if !amaltheasession.Spec.Hibernated {
 		hibernationDate := status.WillHibernateAt
 		if status.State != amaltheadevv1alpha1.Hibernated && needsScaleDown(hibernationDate) {
 			amaltheasession.Spec.Hibernated = true

--- a/internal/controller/cull.go
+++ b/internal/controller/cull.go
@@ -32,7 +32,8 @@ import (
 func updateHibernationState(ctx context.Context, r *AmaltheaSessionReconciler, amaltheasession *amaltheadevv1alpha1.AmaltheaSession) error {
 	status := amaltheasession.Status
 	log := log.FromContext(ctx)
-	if !amaltheasession.Spec.Hibernated {
+	interactive := amaltheasession.Spec.SessionType == amaltheadevv1alpha1.SessionTypeInteractive
+	if !amaltheasession.Spec.Hibernated && interactive { // hibernating only applies to interactive sessions, jobs are managed for that by k8s
 		hibernationDate := status.WillHibernateAt
 		if status.State != amaltheadevv1alpha1.Hibernated && needsScaleDown(hibernationDate) {
 			amaltheasession.Spec.Hibernated = true
@@ -40,7 +41,7 @@ func updateHibernationState(ctx context.Context, r *AmaltheaSessionReconciler, a
 			if err != nil {
 				return err
 			}
-			log.Info("statefulSet scaled down or job suspended")
+			log.Info("statefulSet scaled down")
 		}
 	}
 	return nil

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -100,7 +100,7 @@ func podIsCompleted(pod *v1.Pod) bool {
 	return phaseCompleted && totalCnt == completedCnt
 }
 
-func jobIsCompleted(job batchv1.JobStatus) bool {
+func jobIsFinished(job batchv1.JobStatus) bool {
 	for _, c := range job.Conditions {
 		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == v1.ConditionTrue {
 			return true

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	amaltheadevv1alpha1 "github.com/SwissDataScienceCenter/amalthea/api/v1alpha1"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,6 +98,15 @@ func podIsCompleted(pod *v1.Pod) bool {
 	}
 
 	return phaseCompleted && totalCnt == completedCnt
+}
+
+func jobIsCompleted(job batchv1.JobStatus) bool {
+	for _, c := range job.Conditions {
+		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 func metrics(ctx context.Context, clnt metricsv1beta1.PodMetricsesGetter, cr *amaltheadevv1alpha1.AmaltheaSession) (v1.ResourceList, error) {


### PR DESCRIPTION
- Since finished jobs are actively deleted by amalthea, there is no need to specify `ttlSecondsAfterFinished` for a job. It will only introduce a race condition
- Once a job is done (success or failure), amalthea will remove it after `maxHibernatedDuration` is passed
- A finished job must not be touched in the reconcile loop, otherwise it will be restarted
- If a job exceeds its `MaxAge` time, k8s will terminate the pod and the job goes into failed state. This state is now properly propagated to the amalthea session status
- in `cull.go` the jobs are removed from being "hibernated", as this only applies to interactive sessions. Jobs are being removed by k8s automatically due to its `activeDeadlineSeconds` setting


/deploy