### PR TITLE
fix: Return correct non-interactive session state when pod is gone 

### DIFF
--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -547,7 +547,7 @@ func (c ChildResourceUpdates) failureMessage(pod *v1.Pod, job *batchv1.Job) stri
 	if msg != "" {
 		return msg
 	}
-	msg = jobFailureReason(c.Job.Manifest)
+	msg = jobFailureReason(job)
 	if msg != "" {
 		return msg
 	}

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -520,7 +520,7 @@ func (c ChildResourceUpdates) State(cr *amaltheadevv1alpha1.AmaltheaSession, pod
 	case jobIsSuccess(job):
 		return amaltheadevv1alpha1.Succeeded, ""
 	case jobIsFailed(job):
-		return amaltheadevv1alpha1.Failed, "The job failed."
+		return amaltheadevv1alpha1.Failed, "The job has finished with a failure status."
 	default:
 		return amaltheadevv1alpha1.NotReady, ""
 	}

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -503,7 +503,7 @@ func (c ChildResourceUpdates) IsRunning(pod *v1.Pod) bool {
 }
 
 func (c ChildResourceUpdates) State(cr *amaltheadevv1alpha1.AmaltheaSession, pod *v1.Pod, job *batchv1.Job) (amaltheadevv1alpha1.State, string) {
-	msg := c.failureMessage(pod)
+	msg := c.failureMessage(pod, job)
 	switch {
 	case cr.GetDeletionTimestamp() != nil:
 		return amaltheadevv1alpha1.NotReady, ""
@@ -519,14 +519,12 @@ func (c ChildResourceUpdates) State(cr *amaltheadevv1alpha1.AmaltheaSession, pod
 		fallthrough
 	case jobIsSuccess(job):
 		return amaltheadevv1alpha1.Succeeded, ""
-	case jobIsFailed(job):
-		return amaltheadevv1alpha1.Failed, "The job has finished with a failure status."
 	default:
 		return amaltheadevv1alpha1.NotReady, ""
 	}
 }
 
-func (c ChildResourceUpdates) failureMessage(pod *v1.Pod) string {
+func (c ChildResourceUpdates) failureMessage(pod *v1.Pod, job *batchv1.Job) string {
 	msg := podFailureReason(pod)
 	if msg != "" {
 		return msg
@@ -552,6 +550,15 @@ func (c ChildResourceUpdates) failureMessage(pod *v1.Pod) string {
 	msg = jobFailureReason(c.Job.Manifest)
 	if msg != "" {
 		return msg
+	}
+
+	jobFailed, jobMsg := jobIsFailed(job)
+	if jobFailed {
+		if jobMsg == "" {
+			return "The job has finished with a failure status."
+		} else {
+			return jobMsg
+		}
 	}
 
 	return ""

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -502,7 +502,7 @@ func (c ChildResourceUpdates) IsRunning(pod *v1.Pod) bool {
 	return (stsReady || jobReady) && podReady
 }
 
-func (c ChildResourceUpdates) State(cr *amaltheadevv1alpha1.AmaltheaSession, pod *v1.Pod) (amaltheadevv1alpha1.State, string) {
+func (c ChildResourceUpdates) State(cr *amaltheadevv1alpha1.AmaltheaSession, pod *v1.Pod, job *batchv1.Job) (amaltheadevv1alpha1.State, string) {
 	msg := c.failureMessage(pod)
 	switch {
 	case cr.GetDeletionTimestamp() != nil:
@@ -517,6 +517,10 @@ func (c ChildResourceUpdates) State(cr *amaltheadevv1alpha1.AmaltheaSession, pod
 		return amaltheadevv1alpha1.Running, ""
 	case podIsCompleted(pod):
 		return amaltheadevv1alpha1.Succeeded, ""
+	case jobIsSuccess(job):
+		return amaltheadevv1alpha1.Succeeded, ""
+	case jobIsFailed(job):
+		return amaltheadevv1alpha1.Failed, "The job failed."
 	default:
 		return amaltheadevv1alpha1.NotReady, ""
 	}
@@ -748,10 +752,17 @@ func (c ChildResourceUpdates) Status(
 			log.Error(err, "Could not read the session pod when updating the status")
 		}
 	}
+	job, err := cr.GetJob(ctx, r.Client)
+	if err != nil {
+		job = nil
+		if !apierrors.IsNotFound(err) && cr.Spec.SessionType != amaltheadevv1alpha1.SessionTypeInteractive {
+			log.Error(err, "Could not read the session job when updating the status")
+		}
+	}
 
 	idle := false
 	idleSince := cr.Status.IdleSince
-	state, failMsg := c.State(cr, pod)
+	state, failMsg := c.State(cr, pod, job)
 
 	failedSchedulingSince, nextState, err := checkEventsInferedState(ctx, r, cr, state)
 	state = nextState

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -552,15 +552,6 @@ func (c ChildResourceUpdates) failureMessage(pod *v1.Pod, job *batchv1.Job) stri
 		return msg
 	}
 
-	jobFailed, jobMsg := jobIsFailed(job)
-	if jobFailed {
-		if jobMsg == "" {
-			return "The job has finished with a failure status."
-		} else {
-			return jobMsg
-		}
-	}
-
 	return ""
 }
 

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -516,7 +516,7 @@ func (c ChildResourceUpdates) State(cr *amaltheadevv1alpha1.AmaltheaSession, pod
 	case c.IsRunning(pod):
 		return amaltheadevv1alpha1.Running, ""
 	case podIsCompleted(pod):
-		return amaltheadevv1alpha1.Succeeded, ""
+		fallthrough
 	case jobIsSuccess(job):
 		return amaltheadevv1alpha1.Succeeded, ""
 	case jobIsFailed(job):
@@ -755,7 +755,7 @@ func (c ChildResourceUpdates) Status(
 	job, err := cr.GetJob(ctx, r.Client)
 	if err != nil {
 		job = nil
-		if !apierrors.IsNotFound(err) && cr.Spec.SessionType != amaltheadevv1alpha1.SessionTypeInteractive {
+		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Could not read the session job when updating the status")
 		}
 	}

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -93,19 +93,6 @@ func jobIsSuccess(job *batchv1.Job) bool {
 	return false
 }
 
-func jobIsFailed(job *batchv1.Job) (bool, string) {
-	if job == nil {
-		return false, ""
-	}
-	for _, c := range job.Status.Conditions {
-		if c.Type == batchv1.JobFailed && c.Status == v1.ConditionTrue {
-
-			return true, c.Message
-		}
-	}
-	return false, ""
-}
-
 func podIsCompleted(pod *v1.Pod) bool {
 	if pod == nil || pod.GetDeletionTimestamp() != nil {
 		// A missing pod or a pod being deleted is not completed

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -81,6 +81,30 @@ func podIsReady(pod *v1.Pod) bool {
 	return phaseOk && condOk
 }
 
+func jobIsSuccess(job *batchv1.Job) bool {
+	if job == nil {
+		return false
+	}
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete && c.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func jobIsFailed(job *batchv1.Job) bool {
+	if job == nil {
+		return false
+	}
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
 func podIsCompleted(pod *v1.Pod) bool {
 	if pod == nil || pod.GetDeletionTimestamp() != nil {
 		// A missing pod or a pod being deleted is not completed

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -93,16 +93,17 @@ func jobIsSuccess(job *batchv1.Job) bool {
 	return false
 }
 
-func jobIsFailed(job *batchv1.Job) bool {
+func jobIsFailed(job *batchv1.Job) (bool, string) {
 	if job == nil {
-		return false
+		return false, ""
 	}
 	for _, c := range job.Status.Conditions {
 		if c.Type == batchv1.JobFailed && c.Status == v1.ConditionTrue {
-			return true
+
+			return true, c.Message
 		}
 	}
-	return false
+	return false, ""
 }
 
 func podIsCompleted(pod *v1.Pod) bool {


### PR DESCRIPTION
It happens that the pod is gone, but the job and amalthea session still exists. In this case the status of the amalthea session needs to be derived from the job.

/deploy 