### PR TITLE
Wip: try to improve detecting autoscale failure

### DIFF
--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -97,7 +97,7 @@ jobs:
           echo "KUBECONFIG=${KUBECONFIG}" >> "$GITHUB_ENV"
 
       - name: Build and deploy
-        uses: SwissDataScienceCenter/renku-actions/deploy-renku@v1.22.1
+        uses: SwissDataScienceCenter/renku-actions/deploy-renku@leafty/what-da-heck
         env:
           DOCKER_PASSWORD: ${{ secrets.RENKU_DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.RENKU_DOCKER_USERNAME }}

--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -17,7 +17,6 @@ import (
 	"github.com/SwissDataScienceCenter/amalthea/internal/controller/config"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -558,87 +557,6 @@ func (as *AmaltheaSession) GetPodEvents(ctx context.Context, c client.Reader) (*
 		})
 		return &events, nil
 	}
-}
-
-// Return the auto-scaler resource that is associated to the session
-func (as *AmaltheaSession) GetAutoScaler(ctx context.Context, c client.Reader) (*autoscalingv2.HorizontalPodAutoscaler, error) {
-	hpaList := &autoscalingv2.HorizontalPodAutoscalerList{}
-	err := c.List(ctx, hpaList, client.InNamespace(as.Namespace))
-	if err != nil {
-		return nil, err
-	}
-
-	var targetHPA *autoscalingv2.HorizontalPodAutoscaler
-	for i := range hpaList.Items {
-		hpa := &hpaList.Items[i]
-		if hpa.Spec.ScaleTargetRef.Kind == "StatefulSet" &&
-			hpa.Spec.ScaleTargetRef.Name == as.Name &&
-			hpa.Namespace == as.Namespace {
-			targetHPA = hpa
-			break
-		}
-	}
-	return targetHPA, nil
-}
-
-// Return the statefulset of the session
-func (as *AmaltheaSession) GetStatefulSet(ctx context.Context, c client.Reader) (*appsv1.StatefulSet, error) {
-	if as.Spec.SessionType == SessionTypeNonInteractive {
-		return nil, nil
-	}
-	ss := appsv1.StatefulSet{}
-	key := types.NamespacedName{Name: as.Name, Namespace: as.Namespace}
-	err := c.Get(ctx, key, &ss)
-	if err != nil {
-		return nil, err
-	}
-	return &ss, err
-}
-
-func getAutoScaleError(hpa *autoscalingv2.HorizontalPodAutoscaler, ss *appsv1.StatefulSet, scaleTimeout time.Duration) string {
-	for _, cond := range hpa.Status.Conditions {
-		switch cond.Type {
-		case autoscalingv2.AbleToScale:
-			if cond.Status == v1.ConditionFalse {
-				// Backoff limit hit, scale request rejected, or policy violation
-				return fmt.Sprintf("%s: %s", cond.Reason, cond.Message)
-			}
-		case autoscalingv2.ScalingLimited:
-			if cond.Status == v1.ConditionTrue {
-				// Blocked by min/max replicas, quota, or resource limits
-				return fmt.Sprintf("%s: %s", cond.Reason, cond.Message)
-			}
-		case autoscalingv2.ScalingActive:
-			if cond.Status == v1.ConditionFalse {
-				// Metrics unavailable or HPA paused
-				return fmt.Sprintf("%s: %s", cond.Reason, cond.Message)
-			}
-		}
-	}
-
-	desired := hpa.Status.DesiredReplicas
-	ready := ss.Status.ReadyReplicas
-	if desired > ready &&
-		hpa.Status.LastScaleTime != nil &&
-		time.Since(hpa.Status.LastScaleTime.Time) > scaleTimeout {
-		return fmt.Sprintf("Autoscaling timeout of %s exceeded", scaleTimeout)
-	}
-
-	return ""
-}
-
-func (as *AmaltheaSession) AutoScaleFailed(ctx context.Context, c client.Reader, scaleTimeout time.Duration) (string, error) {
-	ss, err := as.GetStatefulSet(ctx, c)
-	if ss == nil || err != nil {
-		return "", err
-	}
-	scaler, err := as.GetAutoScaler(ctx, c)
-	if err != nil || scaler == nil {
-		return "", err
-	}
-
-	msg := getAutoScaleError(scaler, ss, scaleTimeout)
-	return msg, nil
 }
 
 // Returns the list of all the secrets used in this CR

--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -17,6 +17,7 @@ import (
 	"github.com/SwissDataScienceCenter/amalthea/internal/controller/config"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -557,6 +558,87 @@ func (as *AmaltheaSession) GetPodEvents(ctx context.Context, c client.Reader) (*
 		})
 		return &events, nil
 	}
+}
+
+// Return the auto-scaler resource that is associated to the session
+func (as *AmaltheaSession) GetAutoScaler(ctx context.Context, c client.Reader) (*autoscalingv2.HorizontalPodAutoscaler, error) {
+	hpaList := &autoscalingv2.HorizontalPodAutoscalerList{}
+	err := c.List(ctx, hpaList, client.InNamespace(as.Namespace))
+	if err != nil {
+		return nil, err
+	}
+
+	var targetHPA *autoscalingv2.HorizontalPodAutoscaler
+	for i := range hpaList.Items {
+		hpa := &hpaList.Items[i]
+		if hpa.Spec.ScaleTargetRef.Kind == "StatefulSet" &&
+			hpa.Spec.ScaleTargetRef.Name == as.Name &&
+			hpa.Namespace == as.Namespace {
+			targetHPA = hpa
+			break
+		}
+	}
+	return targetHPA, nil
+}
+
+// Return the statefulset of the session
+func (as *AmaltheaSession) GetStatefulSet(ctx context.Context, c client.Reader) (*appsv1.StatefulSet, error) {
+	if as.Spec.SessionType == SessionTypeNonInteractive {
+		return nil, nil
+	}
+	ss := appsv1.StatefulSet{}
+	key := types.NamespacedName{Name: as.Name, Namespace: as.Namespace}
+	err := c.Get(ctx, key, &ss)
+	if err != nil {
+		return nil, err
+	}
+	return &ss, err
+}
+
+func getAutoScaleError(hpa *autoscalingv2.HorizontalPodAutoscaler, ss *appsv1.StatefulSet, scaleTimeout time.Duration) string {
+	for _, cond := range hpa.Status.Conditions {
+		switch cond.Type {
+		case autoscalingv2.AbleToScale:
+			if cond.Status == v1.ConditionFalse {
+				// Backoff limit hit, scale request rejected, or policy violation
+				return fmt.Sprintf("%s: %s", cond.Reason, cond.Message)
+			}
+		case autoscalingv2.ScalingLimited:
+			if cond.Status == v1.ConditionTrue {
+				// Blocked by min/max replicas, quota, or resource limits
+				return fmt.Sprintf("%s: %s", cond.Reason, cond.Message)
+			}
+		case autoscalingv2.ScalingActive:
+			if cond.Status == v1.ConditionFalse {
+				// Metrics unavailable or HPA paused
+				return fmt.Sprintf("%s: %s", cond.Reason, cond.Message)
+			}
+		}
+	}
+
+	desired := hpa.Status.DesiredReplicas
+	ready := ss.Status.ReadyReplicas
+	if desired > ready &&
+		hpa.Status.LastScaleTime != nil &&
+		time.Since(hpa.Status.LastScaleTime.Time) > scaleTimeout {
+		return fmt.Sprintf("Autoscaling timeout of %s exceeded", scaleTimeout)
+	}
+
+	return ""
+}
+
+func (as *AmaltheaSession) AutoScaleFailed(ctx context.Context, c client.Reader, scaleTimeout time.Duration) (string, error) {
+	ss, err := as.GetStatefulSet(ctx, c)
+	if ss == nil || err != nil {
+		return "", err
+	}
+	scaler, err := as.GetAutoScaler(ctx, c)
+	if err != nil || scaler == nil {
+		return "", err
+	}
+
+	msg := getAutoScaleError(scaler, ss, scaleTimeout)
+	return msg, nil
 }
 
 // Returns the list of all the secrets used in this CR

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -63,7 +63,7 @@ type ChildResourceUpdates struct {
 // https://github.com/kubernetes-sigs/metrics-server/blob/9ebbad973db2a54193712c4d9292bbe3eaa849dc/pkg/storage/pod.go#L31
 const freshContainerMinimalAge = 15 * time.Second
 
-const maxWaitForClearFailedScheduling = 90 * time.Second
+const maxWaitForClearFailedScheduling = 5 * time.Minute
 
 func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr *amaltheadevv1alpha1.AmaltheaSession) ChildResourceUpdate[T] { //nolint:gocyclo
 	log := log.FromContext(ctx)
@@ -583,6 +583,7 @@ func EventsInferedState(ctx context.Context, cr *amaltheadevv1alpha1.AmaltheaSes
 	const scheduled = "Scheduled"
 	const triggeredScaleUp = "TriggeredScaleUp"
 	log := log.FromContext(ctx)
+
 	events, err := cr.GetPodEvents(ctx, client)
 	if err != nil {
 		return EisrNone, fmt.Errorf("%v", err)
@@ -590,23 +591,37 @@ func EventsInferedState(ctx context.Context, cr *amaltheadevv1alpha1.AmaltheaSes
 	if events == nil {
 		return EisrNone, nil
 	}
-	for _, v := range slices.Backward(events.Items) {
+	autoScaleFailed, err := cr.AutoScaleFailed(ctx, client, maxWaitForClearFailedScheduling)
+	if err != nil {
+		return EisrNone, fmt.Errorf("%v", err)
+	}
+	if autoScaleFailed != "" {
+		log.Info("Autoscale failed, finally failing", "message", autoScaleFailed)
+		return EisrFinallyFailed, fmt.Errorf("failed scheduling due to autoscaling failed: %s", autoScaleFailed)
+	}
+
+	var waitedTime time.Duration
+	if !cr.Status.FailedSchedulingSince.IsZero() {
+		waitedTime = time.Since(cr.Status.FailedSchedulingSince.Time)
+	}
+
+	for _, v := range events.Items {
 		if v.Reason == failedScheduling {
-			var waitedTime time.Duration
-			if !cr.Status.FailedSchedulingSince.IsZero() {
-				waitedTime = time.Since(cr.Status.FailedSchedulingSince.Time)
-			}
 			if cr.Status.FailedSchedulingSince.IsZero() {
 				log.Info("Found FailedScheduling event, initially failing", "event", v.Message)
 				return EisrInitiallyFailed, nil
-			} else if waitedTime >= maxWaitForClearFailedScheduling {
-				log.Info("Found FailedScheduling event, finally failing", "waited", waitedTime)
-				return EisrFinallyFailed, fmt.Errorf("failed scheduling: %s", v.Message)
 			} else {
-				log.Info("Found FailedScheduling event, temporary failing", "event", v.Message, "waiting", waitedTime)
-				return EisrTemporaryFailed, nil
+				if waitedTime >= maxWaitForClearFailedScheduling {
+					log.Info("Found FailedScheduling event, finally failing", "waited", waitedTime)
+					return EisrFinallyFailed, fmt.Errorf("failed scheduling: %s", v.Message)
+				} else {
+					log.Info("Found FailedScheduling event, temporary failing", "event", v.Message, "waiting", waitedTime)
+					return EisrTemporaryFailed, nil
+				}
 			}
 		}
+	}
+	for _, v := range events.Items {
 		if v.Reason == scheduled || v.Reason == triggeredScaleUp {
 			log.Info("Found a Scheduled or TriggeredScaleUp event", "event", v.Message)
 			return EisrAutoScheduling, nil

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 

--- a/internal/controller/children.go
+++ b/internal/controller/children.go
@@ -62,7 +62,7 @@ type ChildResourceUpdates struct {
 // https://github.com/kubernetes-sigs/metrics-server/blob/9ebbad973db2a54193712c4d9292bbe3eaa849dc/pkg/storage/pod.go#L31
 const freshContainerMinimalAge = 15 * time.Second
 
-const maxWaitForClearFailedScheduling = 5 * time.Minute
+const maxWaitForClearFailedScheduling = 10 * time.Minute
 
 func (c ChildResource[T]) Reconcile(ctx context.Context, clnt client.Client, cr *amaltheadevv1alpha1.AmaltheaSession) ChildResourceUpdate[T] { //nolint:gocyclo
 	log := log.FromContext(ctx)
@@ -561,7 +561,6 @@ const (
 	EisrInitiallyFailed EventsInferedStateResult = "Initially Failed"
 	EisrTemporaryFailed EventsInferedStateResult = "Temporary Failed"
 	EisrFinallyFailed   EventsInferedStateResult = "Finally Failed"
-	EisrAutoScheduling  EventsInferedStateResult = "Auto Scheduling"
 )
 
 // eventsInferedFailure looks into the events of the session pod to
@@ -579,8 +578,6 @@ const (
 // - none of the above
 func EventsInferedState(ctx context.Context, cr *amaltheadevv1alpha1.AmaltheaSession, client client.Reader) (EventsInferedStateResult, error) {
 	const failedScheduling = "FailedScheduling"
-	const scheduled = "Scheduled"
-	const triggeredScaleUp = "TriggeredScaleUp"
 	log := log.FromContext(ctx)
 
 	events, err := cr.GetPodEvents(ctx, client)
@@ -589,14 +586,6 @@ func EventsInferedState(ctx context.Context, cr *amaltheadevv1alpha1.AmaltheaSes
 	}
 	if events == nil {
 		return EisrNone, nil
-	}
-	autoScaleFailed, err := cr.AutoScaleFailed(ctx, client, maxWaitForClearFailedScheduling)
-	if err != nil {
-		return EisrNone, fmt.Errorf("%v", err)
-	}
-	if autoScaleFailed != "" {
-		log.Info("Autoscale failed, finally failing", "message", autoScaleFailed)
-		return EisrFinallyFailed, fmt.Errorf("failed scheduling due to autoscaling failed: %s", autoScaleFailed)
 	}
 
 	var waitedTime time.Duration
@@ -618,12 +607,6 @@ func EventsInferedState(ctx context.Context, cr *amaltheadevv1alpha1.AmaltheaSes
 					return EisrTemporaryFailed, nil
 				}
 			}
-		}
-	}
-	for _, v := range events.Items {
-		if v.Reason == scheduled || v.Reason == triggeredScaleUp {
-			log.Info("Found a Scheduled or TriggeredScaleUp event", "event", v.Message)
-			return EisrAutoScheduling, nil
 		}
 	}
 	return EisrNone, nil
@@ -737,9 +720,6 @@ func checkEventsInferedState(ctx context.Context,
 		case EisrInitiallyFailed:
 			failedSchedulingSince = metav1.NewTime(time.Now())
 
-		case EisrAutoScheduling:
-			// reset the failedSchedulingSince when a scheduling/trigger-scaleup event occurs
-			failedSchedulingSince = metav1.Time{}
 		default:
 			if err != nil {
 				log.Error(err, "Error obtaining state from pod events")

--- a/internal/controller/children_test.go
+++ b/internal/controller/children_test.go
@@ -122,7 +122,7 @@ func TestEventsInferredStateWhereScheduled(t *testing.T) {
 	}
 	session := v1alpha.AmaltheaSession{}
 	result, err := EventsInferedState(context.TODO(), &session, client)
-	assert.Equal(t, EisrAutoScheduling, result)
+	assert.Equal(t, EisrNone, result)
 	assert.Nil(t, err)
 }
 
@@ -132,7 +132,7 @@ func TestEventsInferredStateWhereTriggeredScaleup(t *testing.T) {
 	}
 	session := v1alpha.AmaltheaSession{}
 	result, err := EventsInferedState(context.TODO(), &session, client)
-	assert.Equal(t, EisrAutoScheduling, result)
+	assert.Equal(t, EisrNone, result)
 	assert.Nil(t, err)
 }
 
@@ -146,7 +146,7 @@ func TestEventsInferredStateWhereTriggeredScaleupAfterFailed(t *testing.T) {
 	}
 	session := v1alpha.AmaltheaSession{}
 	result, err := EventsInferedState(context.TODO(), &session, client)
-	assert.Equal(t, EisrAutoScheduling, result)
+	assert.Equal(t, EisrInitiallyFailed, result)
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
If it is (somewhat reliably) determined that an existing autoscale failed, return early failed condition. otherwise, the timeout is increased until a final failure is returned

Refs: #1154 

/deploy