### PR TITLE
feat: split ci tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,8 +49,13 @@ updates:
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
     groups:
       devcontainer:
         patterns:
           - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,18 +9,125 @@ on:
     - reopened
     - closed
 
+env:
+  DEVCONTAINER_REGISTRY: ghcr.io
+  DEVCONTAINER_IMAGE_NAME: ${{ github.repository }}/devcontainer
+  DEVCONTAINER_IMAGE_TAG_MAIN: "cache-main"
+
 jobs:
-  run-unit-tests:
-    runs-on: ubuntu-24.04
+  build-devcontainer:
+    name: Build devcontainer
+    runs-on: ubuntu-latest
+    outputs:
+      image_repository: ${{ steps.docker_image.outputs.image_repository }}
+      image_tag: ${{ steps.docker_image.outputs.image_tag }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Tests
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.DEVCONTAINER_REGISTRY }}/${{ env.DEVCONTAINER_IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr,prefix=cache-pr-,priority=600
+            type=ref,event=branch,prefix=cache-,priority=500
+            type=ref,event=tag,prefix=cache-,priority=500
+          flavor: |
+            latest=false
+      - name: Extract Docker image name
+        id: docker_image
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          IMAGE=$(echo "$IMAGE_TAGS" | cut -d" " -f1)
+          IMAGE_REPOSITORY=$(echo "$IMAGE" | cut -d":" -f1)
+          IMAGE_TAG=$(echo "$IMAGE" | cut -d":" -f2)
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "image_repository=$IMAGE_REPOSITORY" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pre-build devcontainer
+        uses: devcontainers/ci@v0.3
+        continue-on-error: true
+        with:
+          push: always
+          skipContainerUserIdUpdate: false
+          imageName: ${{ steps.docker_image.outputs.image_repository }}
+          imageTag: ${{ steps.docker_image.outputs.image_tag }}
+          cacheFrom: |
+            ${{ steps.docker_image.outputs.image_repository }}:${{ steps.docker_image.outputs.image_tag }}
+            ${{ steps.docker_image.outputs.image_repository }}:${{ env.DEVCONTAINER_IMAGE_TAG_MAIN }}
+
+  run-lint:
+    name: Run lint
+    runs-on: ubuntu-24.04
+    needs:
+      - build-devcontainer
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Lint
         uses: devcontainers/ci@v0.3
         with:
+          cacheFrom: ${{ needs.build-devcontainer.outputs.image_repository }}:${{ needs.build-devcontainer.outputs.image_tag }}
+          runCmd: make lint
+          push: never
+          skipContainerUserIdUpdate: false
+
+  run-unit-tests:
+    name: Run unit tests
+    runs-on: ubuntu-24.04
+    needs:
+      - build-devcontainer
+      - run-lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Unit tests
+        uses: devcontainers/ci@v0.3
+        with:
+          cacheFrom: ${{ needs.build-devcontainer.outputs.image_repository }}:${{ needs.build-devcontainer.outputs.image_tag }}
+          runCmd: make test
+          push: never
+          skipContainerUserIdUpdate: false
+
+  run-e2e-tests:
+    name: Run e2e tests
+    runs-on: ubuntu-24.04
+    needs:
+      - build-devcontainer
+      - run-lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: e2e tests
+        uses: devcontainers/ci@v0.3
+        with:
+          cacheFrom: ${{ needs.build-devcontainer.outputs.image_repository }}:${{ needs.build-devcontainer.outputs.image_tag }}
+          runCmd: make test-e2e KIND_CLUSTER=kind
+          push: never
+          skipContainerUserIdUpdate: false
+
+  run-helm-checks:
+    name: Run helm checks
+    runs-on: ubuntu-24.04
+    needs:
+      - build-devcontainer
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Helm checks
+        uses: devcontainers/ci@v0.3
+        with:
+          cacheFrom: ${{ needs.build-devcontainer.outputs.image_repository }}:${{ needs.build-devcontainer.outputs.image_tag }}
           runCmd: |
-            make lint && \
-            make test && \
-            make test-e2e KIND_CLUSTER=kind && \
             helm dep update helm-chart/amalthea-sessions && \
             helm lint helm-chart/amalthea-sessions
           push: never


### PR DESCRIPTION
## Describe your changes

This PR modifies the tests workflow so that each set of checks are done independently.

This allows for easier job restart when e.g. the e2e tests are failing without re-running the unit tests or lint that already passed.

The devcontainer handling has been taken from renku-data-services.

