### PR TITLE
feat: propagate session resource requests to SLURM for FirecREST remote sessions

### DIFF
--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -1052,33 +1052,14 @@ func (cr *AmaltheaSession) sessionContainerRemote(volumeMounts []v1.VolumeMount)
 
 	var cpuValue, memoryValue, gpuValue string
 
-	if cpuQ, ok := resources.Requests[v1.ResourceCPU]; ok && !cpuQ.IsZero() {
-		cpuValue = strconv.FormatInt((cpuQ.MilliValue()+999)/1000, 10)
-	} else if cpuQ, ok := resources.Limits[v1.ResourceCPU]; ok && !cpuQ.IsZero() {
-		cpuValue = strconv.FormatInt((cpuQ.MilliValue()+999)/1000, 10)
+	if q := resourceValue(resources, v1.ResourceCPU); !q.IsZero() {
+		cpuValue = strconv.FormatInt((q.MilliValue()+999)/1000, 10) // ceil(milli/1000)
 	}
-
-	if memQ, ok := resources.Requests[v1.ResourceMemory]; ok && !memQ.IsZero() {
-		memoryValue = strconv.FormatInt(memQ.Value()/(1024*1024), 10)
-	} else if memQ, ok := resources.Limits[v1.ResourceMemory]; ok && !memQ.IsZero() {
-		memoryValue = strconv.FormatInt(memQ.Value()/(1024*1024), 10)
+	if q := resourceValue(resources, v1.ResourceMemory); !q.IsZero() {
+		memoryValue = strconv.FormatInt(q.Value()/(1024*1024), 10)
 	}
-
-	var gpuCount int64
-	for name, q := range resources.Requests {
-		if strings.HasSuffix(string(name), "/gpu") {
-			gpuCount += q.Value()
-		}
-	}
-	if gpuCount == 0 {
-		for name, q := range resources.Limits {
-			if strings.HasSuffix(string(name), "/gpu") {
-				gpuCount += q.Value()
-			}
-		}
-	}
-	if gpuCount > 0 {
-		gpuValue = strconv.FormatInt(gpuCount, 10)
+	if q := resourceValue(resources, v1.ResourceName("nvidia.com/gpu")); !q.IsZero() {
+		gpuValue = strconv.FormatInt(q.Value(), 10)
 	}
 
 	sessionContainer.Env = append(
@@ -1120,6 +1101,18 @@ func (cr *AmaltheaSession) sessionContainerRemote(volumeMounts []v1.VolumeMount)
 	}
 
 	return sessionContainer
+}
+
+// resourceValue returns q[name] from Requests, falling back to Limits
+// (what the node actually reserves), or zero when neither is set.
+func resourceValue(res v1.ResourceRequirements, name v1.ResourceName) resource.Quantity {
+	if q, ok := res.Requests[name]; ok && !q.IsZero() {
+		return q
+	}
+	if q, ok := res.Limits[name]; ok && !q.IsZero() {
+		return q
+	}
+	return resource.Quantity{}
 }
 
 // tunnelContainer returns the tunnel container for remote sessions

--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1045,6 +1046,46 @@ func (cr *AmaltheaSession) sessionContainerRemote(volumeMounts []v1.VolumeMount)
 				}),
 			}),
 		},
+	)
+
+	resources := session.Resources
+
+	var cpuValue, memoryValue, gpuValue string
+
+	if cpuQ, ok := resources.Requests[v1.ResourceCPU]; ok && !cpuQ.IsZero() {
+		cpuValue = strconv.FormatInt((cpuQ.MilliValue()+999)/1000, 10)
+	} else if cpuQ, ok := resources.Limits[v1.ResourceCPU]; ok && !cpuQ.IsZero() {
+		cpuValue = strconv.FormatInt((cpuQ.MilliValue()+999)/1000, 10)
+	}
+
+	if memQ, ok := resources.Requests[v1.ResourceMemory]; ok && !memQ.IsZero() {
+		memoryValue = strconv.FormatInt(memQ.Value()/(1024*1024), 10)
+	} else if memQ, ok := resources.Limits[v1.ResourceMemory]; ok && !memQ.IsZero() {
+		memoryValue = strconv.FormatInt(memQ.Value()/(1024*1024), 10)
+	}
+
+	var gpuCount int64
+	for name, q := range resources.Requests {
+		if strings.HasSuffix(string(name), "/gpu") {
+			gpuCount += q.Value()
+		}
+	}
+	if gpuCount == 0 {
+		for name, q := range resources.Limits {
+			if strings.HasSuffix(string(name), "/gpu") {
+				gpuCount += q.Value()
+			}
+		}
+	}
+	if gpuCount > 0 {
+		gpuValue = strconv.FormatInt(gpuCount, 10)
+	}
+
+	sessionContainer.Env = append(
+		sessionContainer.Env,
+		v1.EnvVar{Name: "RSC_SESSION_CPU", Value: cpuValue},
+		v1.EnvVar{Name: "RSC_SESSION_MEMORY", Value: memoryValue},
+		v1.EnvVar{Name: "RSC_SESSION_GPUS", Value: gpuValue},
 	)
 
 	if session.RemoteSecretRef != nil {

--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -1053,7 +1053,7 @@ func (cr *AmaltheaSession) sessionContainerRemote(volumeMounts []v1.VolumeMount)
 	var cpuValue, memoryValue, gpuValue string
 
 	if q := resourceValue(resources, v1.ResourceCPU); !q.IsZero() {
-		cpuValue = strconv.FormatInt((q.MilliValue()+999)/1000, 10) // ceil(milli/1000)
+		cpuValue = strconv.FormatInt(q.Value(), 10)
 	}
 	if q := resourceValue(resources, v1.ResourceMemory); !q.IsZero() {
 		memoryValue = strconv.FormatInt(q.Value()/(1024*1024), 10)

--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -57,6 +57,8 @@ var useNoneSameSiteSessionCookie = getUseNoneSameSiteSessionCookie()
 
 const rcloneStorageSecretNameAnnotation = "csi-rclone.dev/secretName"
 
+const oneMebiByte int64 = 1024*1024
+
 func (cr *AmaltheaSession) SessionVolumes() ([]v1.Volume, []v1.VolumeMount) {
 	pvc := cr.PVC()
 	volumes := []v1.Volume{
@@ -1056,7 +1058,7 @@ func (cr *AmaltheaSession) sessionContainerRemote(volumeMounts []v1.VolumeMount)
 		cpuValue = strconv.FormatInt(q.Value(), 10)
 	}
 	if q := resourceValue(resources, v1.ResourceMemory); !q.IsZero() {
-		memoryValue = strconv.FormatInt(q.Value()/(1024*1024), 10)
+		memoryValue = strconv.FormatInt(q.Value()/oneMebiByte, 10)
 	}
 	if q := resourceValue(resources, v1.ResourceName("nvidia.com/gpu")); !q.IsZero() {
 		gpuValue = strconv.FormatInt(q.Value(), 10)

--- a/api/v1alpha1/amaltheasession_children.go
+++ b/api/v1alpha1/amaltheasession_children.go
@@ -57,7 +57,7 @@ var useNoneSameSiteSessionCookie = getUseNoneSameSiteSessionCookie()
 
 const rcloneStorageSecretNameAnnotation = "csi-rclone.dev/secretName"
 
-const oneMebiByte int64 = 1024*1024
+const oneMebiByte int64 = 1024 * 1024
 
 func (cr *AmaltheaSession) SessionVolumes() ([]v1.Volume, []v1.VolumeMount) {
 	pvc := cr.PVC()

--- a/api/v1alpha1/amaltheasession_children_test.go
+++ b/api/v1alpha1/amaltheasession_children_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -63,4 +64,64 @@ func TestGetPodEventsSorted(t *testing.T) {
 	res, err := session.GetPodEvents(context.TODO(), clnt)
 	assert.Nil(t, err)
 	assert.Equal(t, res.Items, []v1.Event{ev3, ev2, ev1})
+}
+
+func TestSessionContainerRemoteResources(t *testing.T) {
+	cases := []struct {
+		name string
+		reqs v1.ResourceList
+		lims v1.ResourceList
+		cpu  string
+		mem  string
+		gpus string
+	}{
+		{
+			name: "requests",
+			reqs: v1.ResourceList{
+				v1.ResourceCPU:                    resource.MustParse("1500m"),
+				v1.ResourceMemory:                 resource.MustParse("2Gi"),
+				v1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
+				v1.ResourceName("amd.com/gpu"):    resource.MustParse("3"),
+			},
+			cpu:  "2",
+			mem:  "2048",
+			gpus: "5",
+		},
+		{
+			name: "limits fallback",
+			lims: v1.ResourceList{
+				v1.ResourceCPU:                    resource.MustParse("2500m"),
+				v1.ResourceMemory:                 resource.MustParse("3Gi"),
+				v1.ResourceName("nvidia.com/gpu"): resource.MustParse("4"),
+			},
+			cpu:  "3",
+			mem:  "3072",
+			gpus: "4",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := &AmaltheaSession{
+				Spec: AmaltheaSessionSpec{
+					SessionLocation: Remote,
+					Session: Session{
+						Image:     "my-image",
+						Resources: v1.ResourceRequirements{Requests: tc.reqs, Limits: tc.lims},
+					},
+				},
+			}
+
+			container := cr.sessionContainerRemote(nil)
+
+			envMap := make(map[string]string)
+			for _, e := range container.Env {
+				envMap[e.Name] = e.Value
+			}
+
+			assert.Equal(t, tc.cpu, envMap["RSC_SESSION_CPU"])
+			assert.Equal(t, tc.mem, envMap["RSC_SESSION_MEMORY"])
+			assert.Equal(t, tc.gpus, envMap["RSC_SESSION_GPUS"])
+		})
+	}
 }

--- a/api/v1alpha1/amaltheasession_children_test.go
+++ b/api/v1alpha1/amaltheasession_children_test.go
@@ -81,11 +81,10 @@ func TestSessionContainerRemoteResources(t *testing.T) {
 				v1.ResourceCPU:                    resource.MustParse("1500m"),
 				v1.ResourceMemory:                 resource.MustParse("2Gi"),
 				v1.ResourceName("nvidia.com/gpu"): resource.MustParse("2"),
-				v1.ResourceName("amd.com/gpu"):    resource.MustParse("3"),
 			},
 			cpu:  "2",
 			mem:  "2048",
-			gpus: "5",
+			gpus: "2",
 		},
 		{
 			name: "limits fallback",
@@ -97,6 +96,30 @@ func TestSessionContainerRemoteResources(t *testing.T) {
 			cpu:  "3",
 			mem:  "3072",
 			gpus: "4",
+		},
+		{
+			name: "cpu only",
+			reqs: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("2"),
+			},
+			cpu: "2",
+		},
+		{
+			name: "memory only",
+			reqs: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			mem: "1024",
+		},
+		{
+			name: "gpu only",
+			reqs: v1.ResourceList{
+				v1.ResourceName("nvidia.com/gpu"): resource.MustParse("3"),
+			},
+			gpus: "3",
+		},
+		{
+			name: "nothing set",
 		},
 	}
 

--- a/internal/remote/firecrest/controller.go
+++ b/internal/remote/firecrest/controller.go
@@ -758,7 +758,7 @@ func addSbatchDirectivesToScript(sessionScript, partition string) string {
 		directives = append(directives, fmt.Sprintf("#SBATCH --account=%s", slurmAccount))
 	}
 
-	if os.Getenv("RSC_FIRECREST_IGNORE_RESOURCE_CLASS_VALUES") != "true" {
+	if strings.ToLower(os.Getenv("RSC_FIRECREST_FORWARD_RESOURCE_VALUES")) == "true" {
 		if cpu := os.Getenv("RSC_SESSION_CPU"); cpu != "" {
 			directives = append(directives, fmt.Sprintf("#SBATCH --cpus-per-task=%s", cpu))
 		}

--- a/internal/remote/firecrest/controller.go
+++ b/internal/remote/firecrest/controller.go
@@ -757,6 +757,19 @@ func addSbatchDirectivesToScript(sessionScript, partition string) string {
 	if slurmAccount != "" {
 		directives = append(directives, fmt.Sprintf("#SBATCH --account=%s", slurmAccount))
 	}
+
+	if os.Getenv("RSC_FIRECREST_IGNORE_RESOURCE_CLASS_VALUES") != "true" {
+		if cpu := os.Getenv("RSC_SESSION_CPU"); cpu != "" {
+			directives = append(directives, fmt.Sprintf("#SBATCH --cpus-per-task=%s", cpu))
+		}
+		if mem := os.Getenv("RSC_SESSION_MEMORY"); mem != "" {
+			directives = append(directives, fmt.Sprintf("#SBATCH --mem=%sM", mem))
+		}
+		if gpus := os.Getenv("RSC_SESSION_GPUS"); gpus != "" {
+			directives = append(directives, fmt.Sprintf("#SBATCH --gpus=%s", gpus))
+		}
+	}
+
 	directivesStr := strings.Join(directives, "\n")
 	return strings.Replace(sessionScript, "#{{SBATCH_DIRECTIVES_PLACEHOLDER}}", directivesStr, 1)
 }

--- a/internal/remote/firecrest/controller_test.go
+++ b/internal/remote/firecrest/controller_test.go
@@ -84,6 +84,8 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 
 	t.Run("only cpu provided", func(t *testing.T) {
 		t.Setenv("RSC_SESSION_CPU", "4")
+		t.Setenv("RSC_SESSION_MEMORY", "")
+		t.Setenv("RSC_SESSION_GPUS", "")
 
 		script := renderSessionScriptStatic(sessionScript, partition, &fileSystems, secretsPath)
 		assert.Contains(t, script, "#SBATCH --cpus-per-task=4")

--- a/internal/remote/firecrest/controller_test.go
+++ b/internal/remote/firecrest/controller_test.go
@@ -63,6 +63,7 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 		t.Setenv("RSC_SESSION_CPU", "2")
 		t.Setenv("RSC_SESSION_MEMORY", "2048")
 		t.Setenv("RSC_SESSION_GPUS", "1")
+		t.Setenv("RSC_FIRECREST_FORWARD_RESOURCE_VALUES", "true")
 
 		script := renderSessionScriptStatic(sessionScript, partition, &fileSystems, secretsPath)
 		assert.Contains(t, script, "#SBATCH --cpus-per-task=2")
@@ -70,11 +71,10 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 		assert.Contains(t, script, "#SBATCH --gpus=1")
 	})
 
-	t.Run("ignore flag omits resources", func(t *testing.T) {
+	t.Run("forward flag off omits resources", func(t *testing.T) {
 		t.Setenv("RSC_SESSION_CPU", "2")
 		t.Setenv("RSC_SESSION_MEMORY", "2048")
 		t.Setenv("RSC_SESSION_GPUS", "1")
-		t.Setenv("RSC_FIRECREST_IGNORE_RESOURCE_CLASS_VALUES", "true")
 
 		script := renderSessionScriptStatic(sessionScript, partition, &fileSystems, secretsPath)
 		assert.NotContains(t, script, "--cpus-per-task")
@@ -86,6 +86,7 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 		t.Setenv("RSC_SESSION_CPU", "4")
 		t.Setenv("RSC_SESSION_MEMORY", "")
 		t.Setenv("RSC_SESSION_GPUS", "")
+		t.Setenv("RSC_FIRECREST_FORWARD_RESOURCE_VALUES", "true")
 
 		script := renderSessionScriptStatic(sessionScript, partition, &fileSystems, secretsPath)
 		assert.Contains(t, script, "#SBATCH --cpus-per-task=4")

--- a/internal/remote/firecrest/controller_test.go
+++ b/internal/remote/firecrest/controller_test.go
@@ -58,6 +58,38 @@ func TestRenderSessionScriptStatic(t *testing.T) {
 	assert.Contains(t, foundMounts, "\"/store\"")
 	assert.Contains(t, foundMounts, "\"/users:/home/users:ro\"")
 	assert.Contains(t, foundMounts, "\"/secrets:/secrets:ro\"")
+
+	t.Run("resources provided", func(t *testing.T) {
+		t.Setenv("RSC_SESSION_CPU", "2")
+		t.Setenv("RSC_SESSION_MEMORY", "2048")
+		t.Setenv("RSC_SESSION_GPUS", "1")
+
+		script := renderSessionScriptStatic(sessionScript, partition, &fileSystems, secretsPath)
+		assert.Contains(t, script, "#SBATCH --cpus-per-task=2")
+		assert.Contains(t, script, "#SBATCH --mem=2048M")
+		assert.Contains(t, script, "#SBATCH --gpus=1")
+	})
+
+	t.Run("ignore flag omits resources", func(t *testing.T) {
+		t.Setenv("RSC_SESSION_CPU", "2")
+		t.Setenv("RSC_SESSION_MEMORY", "2048")
+		t.Setenv("RSC_SESSION_GPUS", "1")
+		t.Setenv("RSC_FIRECREST_IGNORE_RESOURCE_CLASS_VALUES", "true")
+
+		script := renderSessionScriptStatic(sessionScript, partition, &fileSystems, secretsPath)
+		assert.NotContains(t, script, "--cpus-per-task")
+		assert.NotContains(t, script, "--mem")
+		assert.NotContains(t, script, "--gpus")
+	})
+
+	t.Run("only cpu provided", func(t *testing.T) {
+		t.Setenv("RSC_SESSION_CPU", "4")
+
+		script := renderSessionScriptStatic(sessionScript, partition, &fileSystems, secretsPath)
+		assert.Contains(t, script, "#SBATCH --cpus-per-task=4")
+		assert.NotContains(t, script, "--mem")
+		assert.NotContains(t, script, "--gpus")
+	})
 }
 
 func TestStreamsToFetch(t *testing.T) {


### PR DESCRIPTION
## Summary

For remote sessions dispatched via FirecREST, resource requests defined in `AmaltheaSession.Spec.Session.Resources` are now forwarded to the SLURM job script as `#SBATCH` directives. An opt-out environment variable preserves the previous behavior for sites that do not want resource-class values passed to the grid.

## Motivation and context

FirecREST remote sessions were already using SLURM to schedule the session container, but the CPU, memory, and GPU values configured in the custom resource were ignored by the grid. This change lets the grid honor the resource class the user requested, while still allowing sites to fall back to grid defaults when a value is omitted.

## Behavior

- `RSC_SESSION_CPU` is emitted as `#SBATCH --cpus-per-task=<value>`.
- `RSC_SESSION_MEMORY` is emitted as `#SBATCH --mem=<value>M`.
- `RSC_SESSION_GPUS` is emitted as `#SBATCH --gpus=<value>`.
- If any env var is empty, its directive is omitted so the grid default applies.
- If `RSC_FIRECREST_IGNORE_RESOURCE_CLASS_VALUES` is set to the literal string `"true"`, all resource directives are omitted and the previous behavior is preserved.

## Changes

- `api/v1alpha1/amaltheasession_children.go`
  - `sessionContainerRemote()` now exposes three new environment variables derived from `session.Resources`:
    - `RSC_SESSION_CPU` — integer CPU count, computed as `ceil(milliCPU / 1000)`.
    - `RSC_SESSION_MEMORY` — memory in mebibytes.
    - `RSC_SESSION_GPUS` — sum of all resource keys ending in `/gpu` (supports multi-vendor GPU requests).
  - Falls back from `Requests` to `Limits` for CPU and memory when requests are empty.

- `internal/remote/firecrest/controller.go`
  - `addSbatchDirectivesToScript()` consumes the new env vars and emits the directives described in **Behavior**.
  - Existing directives (`--nodes=1`, `--ntasks-per-node=1`, `--partition`, `--account`) remain unchanged.

- Tests
  - Added `TestSessionContainerRemoteResources` and `TestSessionContainerRemoteResourcesLimitsFallback` in `api/v1alpha1/amaltheasession_children_test.go`.
  - Extended `TestRenderSessionScriptStatic` in `internal/remote/firecrest/controller_test.go` with subtests for resources provided, ignore-flag omission, and CPU-only resources.
