### PR TITLE
feat: select free port on firecrest remote sessions

### DIFF
--- a/internal/remote/firecrest/session_script.sh
+++ b/internal/remote/firecrest/session_script.sh
@@ -147,6 +147,21 @@ mkdir -p "${LOGS_DIR}"
 wstunnel=$(install_wstunnel)
 echo "wstunnel: ${wstunnel}"
 
+# Finds a free IPv4 TCP port by briefly binding with nc. Enroot shares the host
+# network namespace, so co-located sessions collide on fixed ports; only the
+# local (node) binds are reselected, the remote session port is preserved.
+find_free_port() {
+    # $1: blank-separated ports already taken by us (never re-pick them)
+    local used=" $1 " p rc
+    for ((p = 20000 + RANDOM % 10000; p < 32000; p++)); do
+        [[ $used == *" $p "* ]] && continue
+        rc=0; timeout 0.05 nc -l -p "$p" &>/dev/null || rc=$?
+        ((rc == 124)) && { echo "$p"; return 0; }   # timed out => bind held => free
+    done
+    return 1
+}
+
+
 # Ensure NVIDIA_VISIBLE_DEVICES is set to void 
 # so that cuda enabled images work on eiger
 if !(nvidia-smi 2>&1 >/dev/null); then

--- a/internal/remote/firecrest/session_script.sh
+++ b/internal/remote/firecrest/session_script.sh
@@ -203,9 +203,16 @@ echo "TODO: setup rclone mounts..."
 # EOF
 # "${rclone}" mount --config "${RCLONE_CONFIG}" --daemon --read-only era5: "${SESSION_WORK_DIR}/era5"
 
+# listen ports: get free local port - use standard remote port
+RENKU_SESSION_REMOTE_PORT="${RENKU_SESSION_PORT:-8888}"
+RENKU_SESSION_PORT="$(find_free_port)"
+export RENKU_SESSION_PORT RENKU_SESSION_REMOTE_PORT
+GIT_PROXY_REMOTE_PORT="${GIT_PROXY_PORT:-65480}"
+GIT_PROXY_PORT="$(find_free_port "$RENKU_SESSION_PORT")"
+GIT_PROXY_HEALTH_REMOTE_PORT="${GIT_PROXY_HEALTH_PORT:-65481}"
+GIT_PROXY_HEALTH_PORT="$(find_free_port "$RENKU_SESSION_PORT $GIT_PROXY_PORT")"
+export GIT_PROXY_PORT GIT_PROXY_REMOTE_PORT GIT_PROXY_HEALTH_PORT GIT_PROXY_HEALTH_REMOTE_PORT
 # echo "Starting tunnel..."
-GIT_PROXY_PORT="${GIT_PROXY_PORT:-65480}"
-GIT_PROXY_HEALTH_PORT="${GIT_PROXY_HEALTH_PORT:-65481}"
 WSTUNNEL_PATH_PREFIX="${WSTUNNEL_PATH_PREFIX:-sessions/my-session/wstunnel}"
 echo "wstunnel client \
   -R tcp://0.0.0.0:${RENKU_SESSION_PORT}:localhost:${RENKU_SESSION_PORT} \

--- a/internal/remote/firecrest/session_script.sh
+++ b/internal/remote/firecrest/session_script.sh
@@ -158,6 +158,7 @@ find_free_port() {
         rc=0; timeout 0.05 nc -l -p "$p" &>/dev/null || rc=$?
         ((rc == 124)) && { echo "$p"; return 0; }   # timed out => bind held => free
     done
+    >&2 echo "ERROR: could not find a free port in the range 20000-31999"
     return 1
 }
 

--- a/internal/remote/firecrest/session_script.sh
+++ b/internal/remote/firecrest/session_script.sh
@@ -268,6 +268,10 @@ if [ -n "${GIT_REPOSITORIES}" ]; then
             echo "repo: ${repo}, branch: ${branch}"
             cd "${RENKU_WORKING_DIR}/${repo}"
             git init || echo "Error: could not run git init" > "ERROR"
+            # Override the proxy in the config copied from k8s (hardcoded 65480) with the
+            # free local port chosen for this session.
+            git config http.proxy "http://localhost:${GIT_PROXY_PORT}" || echo "Error: could not set git http.proxy" > "ERROR"
+            git config http.sslVerify false || echo "Error: could not set git http.sslVerify" > "ERROR"
             git fetch || echo "Error: could not run git fetch" > "ERROR"
             if [ -n "${branch}" ]; then
                 git checkout "${branch}"  || echo "Error: could not run git checkout" > "ERROR"

--- a/internal/remote/firecrest/session_script.sh
+++ b/internal/remote/firecrest/session_script.sh
@@ -215,17 +215,17 @@ export GIT_PROXY_PORT GIT_PROXY_REMOTE_PORT GIT_PROXY_HEALTH_PORT GIT_PROXY_HEAL
 # echo "Starting tunnel..."
 WSTUNNEL_PATH_PREFIX="${WSTUNNEL_PATH_PREFIX:-sessions/my-session/wstunnel}"
 echo "wstunnel client \
-  -R tcp://0.0.0.0:${RENKU_SESSION_PORT}:localhost:${RENKU_SESSION_PORT} \
-  -L tcp://${GIT_PROXY_PORT}:localhost:${GIT_PROXY_PORT} \
-  -L tcp://${GIT_PROXY_HEALTH_PORT}:localhost:${GIT_PROXY_HEALTH_PORT} \
+  -R tcp://0.0.0.0:${RENKU_SESSION_REMOTE_PORT}:localhost:${RENKU_SESSION_PORT} \
+  -L tcp://${GIT_PROXY_PORT}:localhost:${GIT_PROXY_REMOTE_PORT} \
+  -L tcp://${GIT_PROXY_HEALTH_PORT}:localhost:${GIT_PROXY_HEALTH_REMOTE_PORT} \
   wss://${WSTUNNEL_SERVICE_ADDRESS}:${WSTUNNEL_SERVICE_PORT} \
   -P ${WSTUNNEL_PATH_PREFIX} \
   -H Authorization: Bearer <SECRET> \
   --tls-verify-certificate &"
 "${wstunnel}" client \
-  -R "tcp://0.0.0.0:${RENKU_SESSION_PORT}:localhost:${RENKU_SESSION_PORT}" \
-  -L tcp://${GIT_PROXY_PORT}:localhost:${GIT_PROXY_PORT} \
-  -L tcp://${GIT_PROXY_HEALTH_PORT}:localhost:${GIT_PROXY_HEALTH_PORT} \
+  -R "tcp://0.0.0.0:${RENKU_SESSION_REMOTE_PORT}:localhost:${RENKU_SESSION_PORT}" \
+  -L tcp://${GIT_PROXY_PORT}:localhost:${GIT_PROXY_REMOTE_PORT} \
+  -L tcp://${GIT_PROXY_HEALTH_PORT}:localhost:${GIT_PROXY_HEALTH_REMOTE_PORT} \
   "wss://${WSTUNNEL_SERVICE_ADDRESS}:${WSTUNNEL_SERVICE_PORT}" \
   -P "${WSTUNNEL_PATH_PREFIX}" \
   -H "Authorization: Bearer ${WSTUNNEL_SECRET}" \


### PR DESCRIPTION
## Summary
Remote FirecREST sessions on Slurm now pick free local TCP ports for the session, git proxy, and git-proxy health endpoints instead of hardcoded defaults, while keeping the standard ports the Amalthea controller connects to. This prevents collisions between co-located sessions that share the host network namespace.

## Motivation and context
Enroot on the cluster shares the host network namespace, so multiple sessions scheduled on the same node collide on the previously fixed ports (`RENKU_SESSION_PORT=8888`, `GIT_PROXY_PORT=65480`, `GIT_PROXY_HEALTH_PORT=65481`). One session's wstunnel/git-proxy listener would fail to bind or clash with another's, breaking session startup and git operations on multi-tenant nodes.

## Behavior
- A new `find_free_port` helper probes the 20000–31999 range by briefly binding with `nc`, skipping
  ports already chosen for this session, and errors out (with a stderr diagnostic) if none is free.
- Each service now has a locally-selected free port and a fixed remote port:
  - `RENKU_SESSION_PORT` (free) / `RENKU_SESSION_REMOTE_PORT` (`8888`)
  - `GIT_PROXY_PORT` (free) / `GIT_PROXY_REMOTE_PORT` (`65480`)
  - `GIT_PROXY_HEALTH_PORT` (free) / `GIT_PROXY_HEALTH_REMOTE_PORT` (`65481`)
- The wstunnel command is rewired so the Amalthea-facing ports stay on the standard defaults while
  the node-local binds move to the free ports (`-R` exposes the standard remote port forwarding to
  the free local session port; `-L` binds the free local port forwarding to the standard remote
  git-proxy ports).
- For cloned repos, the git config copied from k8s (hardcoded `65480`) is overridden per repo with
  `http.proxy http://localhost:${GIT_PROXY_PORT}` and `http.sslVerify false` before `git fetch`, so
  fetches route through this session's local proxy listener.

## Changes
- `internal/remote/firecrest/session_script.sh`
  - Added `find_free_port` function.
  - Split session/git-proxy/git-proxy-health ports into local (free) and remote (standard) variables
    and exported them.
  - Updated the wstunnel `client` invocation (and its debug echo) to use the new variables.
  - Override `http.proxy` and `http.sslVerify` per repo before `git fetch`.
  - Emit an error to stderr when no free port is found.

## Notes
- The port probe assumes `nc` and `timeout` are present in the remote session image (already a
  dependency of this script's environment).
- No automated tests cover this shell script; recommend manual verification on a node running
  multiple concurrent sessions.
