### PR TITLE
fix: stop logging the full environment on session start

### DIFF
--- a/internal/remote/runai/controller.go
+++ b/internal/remote/runai/controller.go
@@ -105,13 +105,13 @@ func (c *RunaiRemoteSessionController) Start(ctx context.Context) error {
 	}
 
 	c.jobName = fmt.Sprintf("amalthea-%s-%s", c.project, time.Now().Format("20060102-15-04-05"))
-	slog.Info("starting remote session", "project", c.project, "jobName", c.jobName, "env", os.Environ())
+	slog.Info("starting remote session", "project", c.project, "jobName", c.jobName)
 
 	remoteSessionImage := os.Getenv("REMOTE_SESSION_IMAGE")
 
 	// do not do anything if `fakeStart` is true
 	if c.fakeStart {
-		slog.Info("fake start", "jobName", c.jobName, "env", os.Environ())
+		slog.Info("fake start", "jobName", c.jobName)
 		return nil
 	}
 

--- a/internal/remote/runai/controller_test.go
+++ b/internal/remote/runai/controller_test.go
@@ -1,0 +1,45 @@
+package runai
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SwissDataScienceCenter/amalthea/internal/remote/models"
+)
+
+func TestStartDoesNotLogEnvironment(t *testing.T) {
+	const secret = "super-secret-wstunnel-value"
+	t.Setenv("RSC_WSTUNNEL_SECRET", secret)
+	t.Setenv("RENKU_MOUNT_DIR", t.TempDir())
+
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(old) })
+
+	c := &RunaiRemoteSessionController{
+		project:       "test",
+		currentStatus: models.NotReady,
+		statusTicker:  time.NewTicker(time.Minute),
+		fakeStart:     true,
+	}
+	t.Cleanup(c.statusTicker.Stop)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, secret) {
+		t.Fatalf("log output leaked an environment secret")
+	}
+	if strings.Contains(out, "env=") {
+		t.Fatalf("log output contains an environment dump")
+	}
+}


### PR DESCRIPTION
Session start logged the full process environment, which includes secrets such as the tunnel secret. This stops logging the environment.