### PR TITLE
fix: accept documented top-level auth keys and fail closed on empty token

### DIFF
--- a/internal/authproxy/root.go
+++ b/internal/authproxy/root.go
@@ -43,8 +43,13 @@ func loadConfig(cmd *cobra.Command, args []string) error {
 	// https://github.com/spf13/viper/issues/397#issuecomment-1304749092
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		vname := prefix + "." + f.Name
-		if viper.IsSet(vname) {
+		switch {
+		case viper.IsSet(vname) && viper.GetString(vname) != "":
 			err := cmd.Flags().Set(f.Name, viper.GetString(vname))
+			cobra.CheckErr(err)
+		case viper.IsSet(f.Name):
+			// The documented secret format uses top-level keys (e.g. token, cookie_key)
+			err := cmd.Flags().Set(f.Name, viper.GetString(f.Name))
 			cobra.CheckErr(err)
 		}
 	})

--- a/internal/authproxy/serve.go
+++ b/internal/authproxy/serve.go
@@ -177,6 +177,17 @@ func (l *RequestStats) Handle(c echo.Context) error {
 	return c.JSON(http.StatusOK, RequestStatsResponse{LastRequestTime: l.LastRequest})
 }
 
+// checkAuthConfig fails closed when token authentication is enabled but the
+// resolved token is empty. A config file is only passed by the operator for
+// token authenticated sessions, so an empty token there means the proxy would
+// otherwise run without any authentication.
+func checkAuthConfig() error {
+	if config != "" && len(token) == 0 {
+		return fmt.Errorf("token authentication is enabled but the resolved token is empty, refusing to start without authentication")
+	}
+	return nil
+}
+
 func serve(cmd *cobra.Command, args []string) {
 
 	e := echo.New()
@@ -185,6 +196,10 @@ func serve(cmd *cobra.Command, args []string) {
 	e.Logger.SetLevel(log.INFO)
 	if verbose {
 		e.Logger.SetLevel(log.DEBUG)
+	}
+
+	if err := checkAuthConfig(); err != nil {
+		e.Logger.Fatal(err)
 	}
 
 	rs := NewStats()

--- a/internal/authproxy/serve_test.go
+++ b/internal/authproxy/serve_test.go
@@ -1,0 +1,48 @@
+package authproxy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigTopLevelKeys(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(cfgPath, []byte("remote: http://localhost:8080\ntoken: super-secret\ncookie_key: my-cookie\n"), 0o600)
+	require.NoError(t, err)
+
+	cmd, err := Command()
+	require.NoError(t, err)
+	require.NoError(t, cmd.ParseFlags(nil))
+
+	config = cfgPath
+	token = ""
+	cookieKey = ""
+	t.Cleanup(func() { config = ""; token = ""; cookieKey = "" })
+
+	require.NoError(t, loadConfig(cmd, nil))
+	require.Equal(t, "super-secret", token)
+	require.Equal(t, "my-cookie", cookieKey)
+}
+
+func TestCheckAuthConfigFailsClosed(t *testing.T) {
+	t.Cleanup(func() { config = ""; token = "" })
+
+	config = "/etc/authproxy/config"
+	token = ""
+	require.Error(t, checkAuthConfig())
+
+	token = "super-secret"
+	require.NoError(t, checkAuthConfig())
+
+	config = ""
+	token = ""
+	require.NoError(t, checkAuthConfig())
+}


### PR DESCRIPTION
The auth proxy only read prefixed config keys, so the documented top level token and cookie key were ignored and an empty token left the proxy unauthenticated. This accepts the documented top level keys and fails closed on an empty token.